### PR TITLE
Add Idempotency and reentrancy

### DIFF
--- a/src/psycopack/_introspect.py
+++ b/src/psycopack/_introspect.py
@@ -222,3 +222,20 @@ class Introspector:
         results = self.cur.fetchall()
         assert results is not None
         return [Index(name=name, definition=definition) for name, definition in results]
+
+    def trigger_exists(self, *, trigger: str) -> bool:
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                SELECT
+                  1
+                FROM
+                  pg_trigger
+                WHERE
+                  tgname = {trigger};
+                """)
+            )
+            .format(trigger=psycopg.sql.Literal(trigger))
+            .as_string(self.conn)
+        )
+        return bool(self.cur.fetchone())

--- a/src/psycopack/_repack.py
+++ b/src/psycopack/_repack.py
@@ -17,12 +17,11 @@
 #    certain field. TODO: Investigate if doing it the "repack" way is better in
 #    such cases.
 # 7. Add reasonable lock timeouts for operations and failure->retry routines.
-# 8. Add mechanisms so that calling Repack.full() is re-entrant and idempotent.
-# 9. Add reasonable lock_timeout values to prevent ACCESS EXCLUSIVE queries
+# 8. Add reasonable lock_timeout values to prevent ACCESS EXCLUSIVE queries
 #    blocking the queue by failing to acquire locks quickly.
 from textwrap import dedent
 
-from . import _commands, _cur, _identifiers, _introspect
+from . import _commands, _cur, _identifiers, _introspect, _tracker
 from . import _psycopg as psycopg
 
 
@@ -101,36 +100,78 @@ class Repack:
         self.repacked_function = self.function.replace("repack", "repacked")
         self.repacked_trigger = self.trigger.replace("repack", "repacked")
 
+        self.tracker = _tracker.Tracker(
+            table=self.table,
+            conn=self.conn,
+            cur=self.cur,
+            copy_table=self.copy_table,
+            trigger=self.trigger,
+            backfill_log=self.backfill_log,
+            repacked_name=self.repacked_name,
+            repacked_trigger=self.repacked_trigger,
+        )
+
     def full(self) -> None:
         """
         Process a full table repack from beginning to end.
         """
-        self.pre_validate()
-        self.setup_repacking()
-        self.backfill()
-        self.sync_schemas()
-        self.swap()
-        self.clean_up()
+        stage = self.tracker.get_current_stage()
+        if stage == _tracker.Stage.PRE_VALIDATION:
+            self.pre_validate()
+            self.setup_repacking()
+            self.backfill()
+            self.sync_schemas()
+            self.swap()
+            self.clean_up()
+
+        if stage == _tracker.Stage.SETUP:
+            self.setup_repacking()
+            self.backfill()
+            self.sync_schemas()
+            self.swap()
+            self.clean_up()
+
+        if stage == _tracker.Stage.BACKFILL:
+            self.backfill()
+            self.sync_schemas()
+            self.swap()
+            self.clean_up()
+
+        if stage == _tracker.Stage.SYNC_SCHEMAS:
+            self.sync_schemas()
+            self.swap()
+            self.clean_up()
+
+        if stage == _tracker.Stage.SWAP:
+            self.swap()
+            self.clean_up()
+
+        if stage == _tracker.Stage.CLEAN_UP:
+            self.clean_up()
 
     def pre_validate(self) -> None:
-        if self.introspector.table_is_empty(table=self.table):
-            raise TableIsEmpty("No reason to repack an empty table.")
+        with self.tracker.track(_tracker.Stage.PRE_VALIDATION):
+            if self.introspector.table_is_empty(table=self.table):
+                raise TableIsEmpty("No reason to repack an empty table.")
 
     def setup_repacking(self) -> None:
-        self._create_copy_table()
-        self._create_copy_function()
-        self._create_copy_trigger()
-        self._create_backfill_log()
-        self._populate_backfill_log()
+        with self.tracker.track(_tracker.Stage.SETUP):
+            self._create_copy_table()
+            self._create_copy_function()
+            self._create_copy_trigger()
+            self._create_backfill_log()
+            self._populate_backfill_log()
 
     def backfill(self) -> None:
-        self._perform_backfill()
+        with self.tracker.track(_tracker.Stage.BACKFILL):
+            self._perform_backfill()
 
     def sync_schemas(self) -> None:
-        self._create_indexes()
-        self._create_unique_constraints()
-        self._create_check_and_fk_constraints()
-        self._create_referring_fks()
+        with self.tracker.track(_tracker.Stage.SYNC_SCHEMAS):
+            self._create_indexes()
+            self._create_unique_constraints()
+            self._create_check_and_fk_constraints()
+            self._create_referring_fks()
 
     def _create_copy_table(self) -> None:
         # Checks if other relating objects have FKs pointing to the copy table
@@ -340,89 +381,95 @@ class Repack:
         3. Create triggers from the new table to the old table to keep
            both in sync, in case the changes need to be reverted.
         """
-        self.cur.execute("BEGIN;")
-        self.cur.execute(f"LOCK TABLE {self.table} IN ACCESS EXCLUSIVE MODE;")
-        self.cur.execute(f"LOCK TABLE {self.copy_table} IN ACCESS EXCLUSIVE MODE;")
-        self.command.drop_trigger_if_exists(table=self.table, trigger=self.trigger)
-        self.command.drop_function_if_exists(function=self.function)
-        self.command.rename_table(table_from=self.table, table_to=self.repacked_name)
-        self.command.rename_table(table_from=self.copy_table, table_to=self.table)
-        self.command.create_copy_function(
-            function=self.repacked_function,
-            table_from=self.table,
-            table_to=self.repacked_name,
-            columns=self.introspector.get_table_columns(table=self.table),
-        )
-        self.command.drop_trigger_if_exists(
-            table=self.table, trigger=self.repacked_trigger
-        )
-        self.command.create_copy_trigger(
-            trigger_name=self.repacked_trigger,
-            function=self.repacked_function,
-            table_from=self.table,
-            table_to=self.repacked_name,
-        )
-        self.cur.execute("COMMIT;")
+        with self.tracker.track(_tracker.Stage.SWAP):
+            self.cur.execute("BEGIN;")
+            self.cur.execute(f"LOCK TABLE {self.table} IN ACCESS EXCLUSIVE MODE;")
+            self.cur.execute(f"LOCK TABLE {self.copy_table} IN ACCESS EXCLUSIVE MODE;")
+            self.command.drop_trigger_if_exists(table=self.table, trigger=self.trigger)
+            self.command.drop_function_if_exists(function=self.function)
+            self.command.rename_table(
+                table_from=self.table, table_to=self.repacked_name
+            )
+            self.command.rename_table(table_from=self.copy_table, table_to=self.table)
+            self.command.create_copy_function(
+                function=self.repacked_function,
+                table_from=self.table,
+                table_to=self.repacked_name,
+                columns=self.introspector.get_table_columns(table=self.table),
+            )
+            self.command.drop_trigger_if_exists(
+                table=self.table, trigger=self.repacked_trigger
+            )
+            self.command.create_copy_trigger(
+                trigger_name=self.repacked_trigger,
+                function=self.repacked_function,
+                table_from=self.table,
+                table_to=self.repacked_name,
+            )
+            self.cur.execute("COMMIT;")
 
     def clean_up(self) -> None:
-        self.command.drop_trigger_if_exists(
-            table=self.table, trigger=self.repacked_trigger
-        )
-        self.command.drop_function_if_exists(function=self.repacked_function)
-
-        # Rename indexes using a dict data structure to hold names from/to.
-        indexes: dict[str, dict[str, str]] = {}
-        for idx in self.introspector.get_index_def(table=self.repacked_name):
-            sql = idx.definition
-            sql_arr = sql.split(" ON")
-            sql = sql_arr[1].replace(self.repacked_name, self.table)
-            indexes[sql] = {"idx_from": idx.name}
-
-        for idx in self.introspector.get_index_def(table=self.table):
-            sql = idx.definition
-            sql_arr = sql.split(" ON")
-            sql = sql_arr[1]
-            indexes[sql]["idx_to"] = idx.name
-
-        for idx_sql in indexes:
-            index_data = indexes[idx_sql]
-            self.command.rename_index(
-                idx_from=index_data["idx_from"],
-                idx_to=_identifiers.build_postgres_identifier(
-                    [index_data["idx_from"]], "idx_from"
-                ),
+        with self.tracker.track(_tracker.Stage.CLEAN_UP):
+            self.command.drop_trigger_if_exists(
+                table=self.table, trigger=self.repacked_trigger
             )
-            self.command.rename_index(
-                idx_from=index_data["idx_to"],
-                idx_to=index_data["idx_from"],
-            )
+            self.command.drop_function_if_exists(function=self.repacked_function)
 
-        # Rename foreign keys from other tables using a dict data structure to
-        # hold names from/to.
-        table_to_fk: dict[str, dict[str, str]] = {}
-        for fk in self.introspector.get_referring_fks(table=self.repacked_name):
-            table_to_fk[fk.referring_table] = {"cons_from": fk.name}
+            # Rename indexes using a dict data structure to hold names from/to.
+            indexes: dict[str, dict[str, str]] = {}
+            for idx in self.introspector.get_index_def(table=self.repacked_name):
+                sql = idx.definition
+                sql_arr = sql.split(" ON")
+                sql = sql_arr[1].replace(self.repacked_name, self.table)
+                indexes[sql] = {"idx_from": idx.name}
 
-        for fk in self.introspector.get_referring_fks(table=self.table):
-            table_to_fk[fk.referring_table]["cons_to"] = fk.name
+            for idx in self.introspector.get_index_def(table=self.table):
+                sql = idx.definition
+                sql_arr = sql.split(" ON")
+                sql = sql_arr[1]
+                indexes[sql]["idx_to"] = idx.name
 
-        for table in table_to_fk:
-            fk_data = table_to_fk[table]
-            self.command.rename_constraint(
-                table=table,
-                cons_from=fk_data["cons_from"],
-                cons_to=_identifiers.build_postgres_identifier(
-                    [fk_data["cons_from"]], "const_from"
-                ),
-            )
-            self.command.rename_constraint(
-                table=table,
-                cons_from=fk_data["cons_to"],
-                cons_to=fk_data["cons_from"],
-            )
+            for idx_sql in indexes:
+                index_data = indexes[idx_sql]
+                self.command.rename_index(
+                    idx_from=index_data["idx_from"],
+                    idx_to=_identifiers.build_postgres_identifier(
+                        [index_data["idx_from"]], "idx_from"
+                    ),
+                )
+                self.command.rename_index(
+                    idx_from=index_data["idx_to"],
+                    idx_to=index_data["idx_from"],
+                )
 
-        for fk in self.introspector.get_referring_fks(table=self.repacked_name):
-            self.command.drop_constraint(table=fk.referring_table, constraint=fk.name)
+            # Rename foreign keys from other tables using a dict data structure to
+            # hold names from/to.
+            table_to_fk: dict[str, dict[str, str]] = {}
+            for fk in self.introspector.get_referring_fks(table=self.repacked_name):
+                table_to_fk[fk.referring_table] = {"cons_from": fk.name}
 
-        self.command.drop_table_if_exists(table=self.repacked_name)
-        self.command.drop_table_if_exists(table=self.backfill_log)
+            for fk in self.introspector.get_referring_fks(table=self.table):
+                table_to_fk[fk.referring_table]["cons_to"] = fk.name
+
+            for table in table_to_fk:
+                fk_data = table_to_fk[table]
+                self.command.rename_constraint(
+                    table=table,
+                    cons_from=fk_data["cons_from"],
+                    cons_to=_identifiers.build_postgres_identifier(
+                        [fk_data["cons_from"]], "const_from"
+                    ),
+                )
+                self.command.rename_constraint(
+                    table=table,
+                    cons_from=fk_data["cons_to"],
+                    cons_to=fk_data["cons_from"],
+                )
+
+            for fk in self.introspector.get_referring_fks(table=self.repacked_name):
+                self.command.drop_constraint(
+                    table=fk.referring_table, constraint=fk.name
+                )
+
+            self.command.drop_table_if_exists(table=self.repacked_name)
+            self.command.drop_table_if_exists(table=self.backfill_log)

--- a/src/psycopack/_tracker.py
+++ b/src/psycopack/_tracker.py
@@ -1,0 +1,386 @@
+import dataclasses
+import enum
+from contextlib import contextmanager
+from textwrap import dedent
+from typing import Iterator
+
+from . import _commands, _cur, _introspect
+from . import _psycopg as psycopg
+
+
+class TrackerException(Exception):
+    pass
+
+
+class CannotFindUnfinishedStage(TrackerException):
+    pass
+
+
+class InvalidRowInTrackerTable(TrackerException):
+    pass
+
+
+class TableDoesNotExist(TrackerException):
+    pass
+
+
+class TriggerDoesNotExist(TrackerException):
+    pass
+
+
+class StageAlreadyFinished(TrackerException):
+    pass
+
+
+class InvalidRepackingSetup(TrackerException):
+    pass
+
+
+class InvalidRepackingStep(TrackerException):
+    pass
+
+
+@dataclasses.dataclass
+class StageInfo:
+    name: str
+    step: int
+
+
+class Stage(enum.Enum):
+    PRE_VALIDATION = StageInfo(name="PRE_VALIDATION", step=1)
+    SETUP = StageInfo(name="SETUP", step=2)
+    BACKFILL = StageInfo(name="BACKFILL", step=3)
+    SYNC_SCHEMAS = StageInfo(name="SYNC_SCHEMAS", step=4)
+    SWAP = StageInfo(name="SWAP", step=5)
+    CLEAN_UP = StageInfo(name="CLEAN_UP", step=6)
+
+
+class Tracker:
+    """
+    A class to keep track of where in the repacking process a table is.
+
+    It should be used via the two public methods:
+
+      1. `track` (context manager): used to verify if a stage pre-condition
+         is valid, and to log the stage completion once it has exited.
+
+      2. `get_current_stage`: used to verify which stage the repacking process
+         is currently at.
+    """
+
+    def __init__(
+        self,
+        *,
+        table: str,
+        conn: psycopg.Connection,
+        cur: _cur.LoggedCursor,
+        copy_table: str,
+        trigger: str,
+        backfill_log: str,
+        repacked_name: str,
+        repacked_trigger: str,
+    ) -> None:
+        self.table = table
+        self.conn = conn
+        self.cur = cur
+        self.introspector = _introspect.Introspector(conn=self.conn, cur=self.cur)
+        self.command = _commands.Command(conn=self.conn, cur=self.cur)
+
+        self.copy_table = copy_table
+        self.trigger = trigger
+        self.backfill_log = backfill_log
+        self.repacked_name = repacked_name
+        self.repacked_trigger = repacked_trigger
+
+        self.tracker_table = self._get_tracker_table_name()
+        self.tracker_lock = f"{self.tracker_table}_lock"
+        self.initial_stage = Stage.PRE_VALIDATION
+
+    @contextmanager
+    def track(self, stage: Stage) -> Iterator[None]:
+        with self.command.session_lock(name=self.tracker_lock):
+            self._ensure_tracker_table_exists(stage=stage)
+            self._validate_stage(stage=stage)
+            yield
+            self._finish_stage(stage=stage)
+
+    def get_current_stage(self) -> Stage:
+        with self.command.session_lock(name=self.tracker_lock):
+            self._ensure_tracker_table_exists()
+            return self._get_unfinished_stage()
+
+    def _ensure_tracker_table_exists(self, stage: Stage | None = None) -> None:
+        if self._tracker_table_exists():
+            return
+
+        if stage and (stage != self.initial_stage):
+            raise InvalidRepackingSetup(
+                f"The repacking process should be initiated by the "
+                f"{self.initial_stage} stage. Tried to start repacking with "
+                f"{stage} instead."
+            )
+
+        self._create_tracker_table()
+        self._set_stage(stage_from=None, stage_to=self.initial_stage)
+
+    def _validate_stage(self, *, stage: Stage) -> None:
+        self._validate_tracker_table()
+        self._validate_stage_not_finished(stage=stage)
+        self._validate_stage_in_right_sequence(stage=stage)
+        self._validate_stage_dependencies(stage=stage)
+
+    def _validate_stage_not_finished(self, *, stage: Stage) -> None:
+        if self._is_stage_finished(stage=stage):
+            raise StageAlreadyFinished(
+                f"Stage {stage.value.name} has already completed and cannot run again."
+            )
+
+    def _validate_stage_in_right_sequence(self, *, stage: Stage) -> None:
+        unfinished_stage = self._get_unfinished_stage()
+        if stage != unfinished_stage:
+            raise InvalidRepackingStep(
+                f"Cannot run {stage} if the current stage is {unfinished_stage}."
+            )
+
+    def _validate_stage_dependencies(self, *, stage: Stage) -> None:
+        """
+        Check if stage dependencies are still valid.
+
+        This validation should uncover inconsistencies, such as a user manually
+        deleting a table or a trigger that needs to be used by the passed in
+        stage.
+        """
+        table_dependencies = {
+            Stage.SETUP: [self.table],
+            Stage.BACKFILL: [self.table, self.copy_table, self.backfill_log],
+            Stage.SYNC_SCHEMAS: [self.table, self.copy_table],
+            Stage.SWAP: [self.table, self.copy_table],
+            Stage.CLEAN_UP: [self.repacked_name, self.table],
+        }
+        if stage in table_dependencies:
+            for table in table_dependencies[stage]:
+                self._validate_table_exists(table=table, stage=stage)
+
+        trigger_dependencies = {
+            Stage.BACKFILL: [self.trigger],
+            Stage.SYNC_SCHEMAS: [self.trigger],
+            Stage.SWAP: [self.trigger],
+            Stage.CLEAN_UP: [self.repacked_trigger],
+        }
+        if stage in trigger_dependencies:
+            for trigger in trigger_dependencies[stage]:
+                self._validate_trigger_exists(trigger=trigger, stage=stage)
+
+    def _finish_stage(self, *, stage: Stage) -> None:
+        match stage:
+            case Stage.PRE_VALIDATION:
+                self._set_stage(stage_from=stage, stage_to=Stage.SETUP)
+                return
+            case Stage.SETUP:
+                self._set_stage(stage_from=stage, stage_to=Stage.BACKFILL)
+                return
+            case Stage.BACKFILL:
+                self._set_stage(stage_from=stage, stage_to=Stage.SYNC_SCHEMAS)
+                return
+            case Stage.SYNC_SCHEMAS:
+                self._set_stage(stage_from=stage, stage_to=Stage.SWAP)
+                return
+            case Stage.SWAP:
+                self._set_stage(stage_from=stage, stage_to=Stage.CLEAN_UP)
+                return
+            case Stage.CLEAN_UP:
+                # Repacking is done. We have to drop the tracker table as well
+                # to not leave any repacking relations behind.
+                self.command.drop_table_if_exists(table=self.tracker_table)
+                return
+            case _:  # pragma: no cover
+                raise ValueError("Invalid Stage")
+
+    def _set_stage(self, *, stage_from: Stage | None, stage_to: Stage) -> None:
+        self._set_latest_stage_to_finished()
+        self._insert_tracker_stage(
+            stage=stage_to.value.name,
+            step=stage_to.value.step,
+        )
+
+    def _get_tracker_table_name(self) -> str:
+        # Manipulate the copy_table name directly to avoid an extra
+        # introspection query to find the table oid.
+        oid = self.copy_table.split("repack_")[1]
+        return f"repack_{oid}_tracker"
+
+    def _tracker_table_exists(self) -> bool:
+        return bool(self.introspector.get_table_oid(table=self.tracker_table))
+
+    def _create_tracker_table(self) -> None:
+        self.command.drop_table_if_exists(table=self.tracker_table)
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                CREATE TABLE {table} (
+                  stage VARCHAR(32) NOT NULL UNIQUE,
+                  step INTEGER NOT NULL UNIQUE,
+                  started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  finished_at TIMESTAMP NULL
+                );
+                """)
+            )
+            .format(
+                table=psycopg.sql.Identifier(self.tracker_table),
+            )
+            .as_string(self.conn)
+        )
+        # The unique index below will guarantee that there is ever only one row
+        # in the table with finished_at NULL. This represents the logical
+        # constraint of not being possible to carry on two repacking stages at
+        # the same time.
+        # Due to the limitations of having to support lower versions than
+        # Postgres 15, we can't use NULLS NOT DISTINCT and need the workaround
+        # below provided by COALESCE.
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                CREATE UNIQUE INDEX
+                  {index}
+                ON
+                  {table} (COALESCE(finished_at, '1970-01-01 00:00:00'))
+                WHERE
+                  finished_at IS NULL;
+                """)
+            )
+            .format(
+                index=psycopg.sql.Identifier(f"{self.tracker_table}_uniq_idx"),
+                table=psycopg.sql.Identifier(self.tracker_table),
+            )
+            .as_string(self.conn)
+        )
+
+    def _validate_tracker_table(self) -> None:
+        """
+        Verify that the rows in the table have the expected stage names
+        and step numbers in order.
+
+        This ensures that the tracker table hasn't been alterated manually.
+        """
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                SELECT
+                  stage,
+                  step
+                FROM
+                  {table}
+                ORDER BY
+                  step ASC;
+                """)
+            )
+            .format(table=psycopg.sql.Identifier(self.tracker_table))
+            .as_string(self.conn)
+        )
+        result = self.cur.fetchall()
+        expected_stages = sorted(
+            [(stage.value.name, stage.value.step) for stage in Stage],
+            key=lambda s: s[1],
+        )
+        if result != expected_stages[: len(result)]:
+            raise InvalidRowInTrackerTable(
+                f"The tracker table '{self.tracker_table}' has invalid rows."
+            )
+
+    def _get_unfinished_stage(self) -> Stage:
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                SELECT
+                  stage
+                FROM
+                  {table}
+                WHERE
+                  finished_at IS NULL
+                ORDER BY
+                  started_at DESC
+                LIMIT 1;
+                """)
+            )
+            .format(table=psycopg.sql.Identifier(self.tracker_table))
+            .as_string(self.conn)
+        )
+        result = self.cur.fetchone()
+        if not result:
+            raise CannotFindUnfinishedStage(
+                f"The tracker table '{self.tracker_table}' should have a row "
+                "with a null finished_at column. Found none."
+            )
+        return next((stage for stage in Stage if stage.value.name == result[0]))
+
+    def _is_stage_finished(self, *, stage: Stage) -> bool:
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                SELECT
+                  1
+                FROM
+                  {table}
+                WHERE
+                  stage = {stage}
+                  AND finished_at IS NOT NULL;
+                """)
+            )
+            .format(
+                table=psycopg.sql.Identifier(self.tracker_table),
+                stage=psycopg.sql.Literal(stage.value.name),
+            )
+            .as_string(self.conn)
+        )
+        return bool(self.cur.fetchone())
+
+    def _validate_table_exists(self, *, table: str, stage: Stage) -> None:
+        if not self.introspector.get_table_oid(table=table):
+            raise TableDoesNotExist(
+                f"Psycopack {stage.value.name} stage requires the table "
+                f"{table} to proceed. However, the table {table} does not exist."
+            )
+
+    def _validate_trigger_exists(self, *, trigger: str, stage: Stage) -> None:
+        if not self.introspector.trigger_exists(trigger=trigger):
+            raise TriggerDoesNotExist(
+                f"Psycopack {stage.value.name} stage requires the trigger "
+                f"{trigger} to proceed. However, the trigger {trigger} does not exist."
+            )
+
+    def _set_latest_stage_to_finished(self) -> None:
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                UPDATE
+                  {table}
+                SET
+                  finished_at = CURRENT_TIMESTAMP
+                WHERE
+                  finished_at is NULL;
+                """)
+            )
+            .format(
+                table=psycopg.sql.Identifier(self.tracker_table),
+            )
+            .as_string(self.conn)
+        )
+        return
+
+    def _insert_tracker_stage(self, *, stage: str, step: int) -> None:
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                INSERT INTO
+                  {table} (stage, step)
+                VALUES
+                  ({stage}, {step});
+                """)
+            )
+            .format(
+                table=psycopg.sql.Identifier(self.tracker_table),
+                stage=psycopg.sql.Literal(stage),
+                step=psycopg.sql.Literal(step),
+            )
+            .as_string(self.conn)
+        )

--- a/tests/test_repack.py
+++ b/tests/test_repack.py
@@ -9,6 +9,7 @@ from psycopack import (
     _cur,
     _introspect,
     _psycopg,
+    _tracker,
 )
 from tests import factories
 
@@ -95,6 +96,9 @@ def _assert_repack(
     function_info = _get_function_info(repack, cur)
     assert function_info.function_exists is False
     assert function_info.repacked_function_exists is False
+
+    # The tracker table itself will also be deleted after the clean up process.
+    assert repack.introspector.get_table_oid(table=repack.tracker.tracker_table) is None
 
 
 def test_repack_full(connection: _psycopg.Connection) -> None:
@@ -202,6 +206,8 @@ def test_repack_full_after_setup_called(connection: _psycopg.Connection) -> None
         )
         repack.pre_validate()
         repack.setup_repacking()
+        # Setup finished. Next stage is backfill.
+        assert repack.tracker.get_current_stage() == _tracker.Stage.BACKFILL
         repack.full()
         table_after = _collect_table_info(table="to_repack", connection=connection)
         _assert_repack(
@@ -237,6 +243,8 @@ def test_repack_full_after_backfill(connection: _psycopg.Connection) -> None:
         repack.pre_validate()
         repack.setup_repacking()
         repack.backfill()
+        # Backfill finished. Next stage is sync_schemas.
+        assert repack.tracker.get_current_stage() == _tracker.Stage.SYNC_SCHEMAS
         repack.full()
         table_after = _collect_table_info(table="to_repack", connection=connection)
         _assert_repack(
@@ -273,6 +281,8 @@ def test_repack_full_after_sync_schemas_called(connection: _psycopg.Connection) 
         repack.setup_repacking()
         repack.backfill()
         repack.sync_schemas()
+        # Sync schemas finished. Next stage is swap.
+        assert repack.tracker.get_current_stage() == _tracker.Stage.SWAP
         repack.full()
         table_after = _collect_table_info(table="to_repack", connection=connection)
         _assert_repack(
@@ -311,6 +321,8 @@ def test_repack_full_after_swap_called(connection: _psycopg.Connection) -> None:
         repack.backfill()
         repack.sync_schemas()
         repack.swap()
+        # Swap finished. Next stage is clean up.
+        assert repack.tracker.get_current_stage() == _tracker.Stage.CLEAN_UP
         repack.full()
         table_after = _collect_table_info(table="to_repack", connection=connection)
         _assert_repack(
@@ -346,6 +358,285 @@ def test_clean_up_finishes_the_repacking(connection: _psycopg.Connection) -> Non
         repack.sync_schemas()
         repack.swap()
         repack.clean_up()
+        table_after = _collect_table_info(table="to_repack", connection=connection)
+        _assert_repack(
+            table_before=table_before,
+            table_after=table_after,
+            repack=repack,
+            cur=cur,
+        )
+
+
+def test_when_tracker_removed_after_sync_schemas(
+    connection: _psycopg.Connection,
+) -> None:
+    with connection.cursor() as cur:
+        factories.create_table_for_repacking(
+            connection=connection,
+            cur=cur,
+            table_name="to_repack",
+            rows=100,
+        )
+        table_before = _collect_table_info(table="to_repack", connection=connection)
+        repack = Repack(
+            table="to_repack",
+            batch_size=1,
+            conn=connection,
+            cur=cur,
+        )
+
+        repack.pre_validate()
+        repack.setup_repacking()
+        repack.backfill()
+        repack.sync_schemas()
+        assert repack.tracker.get_current_stage() == _tracker.Stage.SWAP
+
+        # Deleting the tracker table will remove the ability to pick up the
+        # repacking process where it left. But nonetheless, it should resume
+        # happily from scratch.
+        repack.command.drop_table_if_exists(table=repack.tracker.tracker_table)
+
+        repack.full()
+        table_after = _collect_table_info(table="to_repack", connection=connection)
+        _assert_repack(
+            table_before=table_before,
+            table_after=table_after,
+            repack=repack,
+            cur=cur,
+        )
+
+
+def test_when_tracker_table_current_row_is_deleted(
+    connection: _psycopg.Connection,
+) -> None:
+    """
+    A sane error must be returned and the repacking process must be stopped if
+    the tracker table has been manipulated.
+
+    In this case, the row containing the current stage has been deleted
+    manually.
+    """
+    with connection.cursor() as cur:
+        factories.create_table_for_repacking(
+            connection=connection,
+            cur=cur,
+            table_name="to_repack",
+            rows=100,
+        )
+        repack = Repack(
+            table="to_repack",
+            batch_size=1,
+            conn=connection,
+            cur=cur,
+        )
+
+        repack.pre_validate()
+        repack.setup_repacking()
+        assert repack.tracker.get_current_stage() == _tracker.Stage.BACKFILL
+
+        cur.execute(
+            f"DELETE FROM {repack.tracker.tracker_table} WHERE stage = 'BACKFILL';"
+        )
+        with pytest.raises(_tracker.CannotFindUnfinishedStage):
+            repack.full()
+
+
+def test_when_rogue_row_inserted_in_tracker_table(
+    connection: _psycopg.Connection,
+) -> None:
+    """
+    A sane error must be returned and the repacking process must be stopped if
+    the tracker table has been manipulated.
+
+    In this case, a new row that shouldn't be there has been inserted into the
+    table manually.
+    """
+    with connection.cursor() as cur:
+        factories.create_table_for_repacking(
+            connection=connection,
+            cur=cur,
+            table_name="to_repack",
+            rows=100,
+        )
+        repack = Repack(
+            table="to_repack",
+            batch_size=1,
+            conn=connection,
+            cur=cur,
+        )
+
+        repack.pre_validate()
+        repack.setup_repacking()
+        assert repack.tracker.get_current_stage() == _tracker.Stage.BACKFILL
+
+        cur.execute(
+            _psycopg.sql.SQL(
+                """
+                INSERT INTO
+                  {table} (stage, step, started_at, finished_at)
+                VALUES
+                  ({stage}, {step}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+                """
+            )
+            .format(
+                table=_psycopg.sql.Identifier(repack.tracker.tracker_table),
+                stage=_psycopg.sql.Literal("A stage that doesn't exist"),
+                step=_psycopg.sql.Literal(42),
+            )
+            .as_string(connection)
+        )
+        with pytest.raises(_tracker.InvalidRowInTrackerTable):
+            repack.full()
+
+
+def test_table_to_repack_deleted_after_pre_validation(
+    connection: _psycopg.Connection,
+) -> None:
+    with connection.cursor() as cur:
+        factories.create_table_for_repacking(
+            connection=connection,
+            cur=cur,
+            table_name="to_repack",
+            rows=100,
+        )
+        repack = Repack(
+            table="to_repack",
+            batch_size=1,
+            conn=connection,
+            cur=cur,
+        )
+
+        repack.pre_validate()
+        assert repack.tracker.get_current_stage() == _tracker.Stage.SETUP
+
+        cur.execute("DROP TABLE to_repack CASCADE;")
+        with pytest.raises(_tracker.TableDoesNotExist):
+            repack.full()
+
+
+def test_trigger_deleted_after_setup(connection: _psycopg.Connection) -> None:
+    with connection.cursor() as cur:
+        factories.create_table_for_repacking(
+            connection=connection,
+            cur=cur,
+            table_name="to_repack",
+            rows=100,
+        )
+        repack = Repack(
+            table="to_repack",
+            batch_size=1,
+            conn=connection,
+            cur=cur,
+        )
+        repack.pre_validate()
+        repack.setup_repacking()
+        assert repack.tracker.get_current_stage() == _tracker.Stage.BACKFILL
+
+        repack.command.drop_trigger_if_exists(
+            table=repack.table, trigger=repack.trigger
+        )
+        with pytest.raises(_tracker.TriggerDoesNotExist):
+            repack.full()
+
+
+def test_cannot_repeat_finished_stage(connection: _psycopg.Connection) -> None:
+    with connection.cursor() as cur:
+        factories.create_table_for_repacking(
+            connection=connection,
+            cur=cur,
+            table_name="to_repack",
+            rows=100,
+        )
+        table_before = _collect_table_info(table="to_repack", connection=connection)
+        repack = Repack(
+            table="to_repack",
+            batch_size=1,
+            conn=connection,
+            cur=cur,
+        )
+        repack.pre_validate()
+        with pytest.raises(_tracker.StageAlreadyFinished):
+            repack.pre_validate()
+
+        repack.setup_repacking()
+        with pytest.raises(_tracker.StageAlreadyFinished):
+            repack.setup_repacking()
+
+        repack.backfill()
+        with pytest.raises(_tracker.StageAlreadyFinished):
+            repack.backfill()
+
+        repack.sync_schemas()
+        with pytest.raises(_tracker.StageAlreadyFinished):
+            repack.sync_schemas()
+
+        repack.swap()
+        with pytest.raises(_tracker.StageAlreadyFinished):
+            repack.swap()
+
+        repack.clean_up()
+        with pytest.raises(_tracker.InvalidRepackingSetup):
+            # The clean up process above already deleted all repacking
+            # relations, including the tracker table. So trying to call it
+            # again indicates trying to start repacking from scratch straight
+            # from the clean up stage, which is invalid.
+            repack.clean_up()
+
+        table_after = _collect_table_info(table="to_repack", connection=connection)
+        _assert_repack(
+            table_before=table_before,
+            table_after=table_after,
+            repack=repack,
+            cur=cur,
+        )
+
+
+def test_cannot_skip_order_of_stages(connection: _psycopg.Connection) -> None:
+    with connection.cursor() as cur:
+        factories.create_table_for_repacking(
+            connection=connection,
+            cur=cur,
+            table_name="to_repack",
+            rows=100,
+        )
+        table_before = _collect_table_info(table="to_repack", connection=connection)
+        repack = Repack(
+            table="to_repack",
+            batch_size=1,
+            conn=connection,
+            cur=cur,
+        )
+        with pytest.raises(_tracker.InvalidRepackingSetup):
+            # Can't initialise a repacking without going through pre-validation
+            # first.
+            repack.setup_repacking()
+
+        repack.pre_validate()
+
+        with pytest.raises(_tracker.InvalidRepackingStep):
+            # Can't go to backfill without setting up first.
+            repack.backfill()
+
+        repack.setup_repacking()
+
+        with pytest.raises(_tracker.InvalidRepackingStep):
+            # Can't go to sync schemas without backfilling first
+            repack.sync_schemas()
+
+        repack.backfill()
+
+        with pytest.raises(_tracker.InvalidRepackingStep):
+            # Can't go to swap without syncing schemas first.
+            repack.swap()
+
+        repack.sync_schemas()
+        with pytest.raises(_tracker.InvalidRepackingStep):
+            # Can't go to clean up without swapping first.
+            repack.clean_up()
+
+        repack.swap()
+        repack.clean_up()
+
         table_after = _collect_table_info(table="to_repack", connection=connection)
         _assert_repack(
             table_before=table_before,


### PR DESCRIPTION
Prior to the change in this PR, there was no way to recover a repacking
process from failure or command interruption.

Under those circumstances, the repacking process would need to start
from scratch and the existing repacking would be wasted.

This can be costly, as repacking a whole table can take a lot of time.

This change introduces a "Tracker" class. Its goal is to keep track of
the repacking process in its totality, so that if it is interrupted, it
can resume from where it left off instead of having to run from scratch.

From a user's perspective, the only thing they need to do is call
Repack.full() until the process finishes. The same as before.

The tracker class acknowledges all the existing repacking stages, and
provides verification to ensure the caller that the current stage of the
repacking hasn't been messed up with.

This is relevant as a user might manually (or accidentally) delete
relations created and required by the repacking process while the
process is still running. Although in many cases this is not a
salvageable situation, the tracker tries its best to return a meaningful
error.

The way the tracker provides idempotency/reentrancy to the repacking
process is by storing information about the completed and ongoing
repacking stages in an auxiliary table, and using this table to verify
the current integrity of the process.