### PR TITLE
Change relation prefixes to be more identifiable

### DIFF
--- a/src/psycopack/_const.py
+++ b/src/psycopack/_const.py
@@ -1,0 +1,2 @@
+NAME_PREFIX = "psycopack"
+REPACKED_NAME_PREFIX = "psycopack_repacked"

--- a/src/psycopack/_repack.py
+++ b/src/psycopack/_repack.py
@@ -21,7 +21,7 @@
 #    blocking the queue by failing to acquire locks quickly.
 from textwrap import dedent
 
-from . import _commands, _cur, _identifiers, _introspect, _tracker
+from . import _commands, _const, _cur, _identifiers, _introspect, _tracker
 from . import _psycopg as psycopg
 
 
@@ -96,9 +96,15 @@ class Repack:
         self.backfill_log = f"{self.copy_table}_backfill"
 
         # Names after the original table once it has been repacked and swapped.
-        self.repacked_name = self.copy_table.replace("repack", "repacked")
-        self.repacked_function = self.function.replace("repack", "repacked")
-        self.repacked_trigger = self.trigger.replace("repack", "repacked")
+        self.repacked_name = self.copy_table.replace(
+            _const.NAME_PREFIX, _const.REPACKED_NAME_PREFIX
+        )
+        self.repacked_function = self.function.replace(
+            _const.NAME_PREFIX, _const.REPACKED_NAME_PREFIX
+        )
+        self.repacked_trigger = self.trigger.replace(
+            _const.NAME_PREFIX, _const.REPACKED_NAME_PREFIX
+        )
 
         self.tracker = _tracker.Tracker(
             table=self.table,
@@ -202,7 +208,7 @@ class Repack:
         oid = self.introspector.get_table_oid(table=self.table)
         if oid is None:
             raise TableDoesNotExist(f'Table "{self.table}" does not exist.')
-        return f"repack_{oid}"
+        return f"{_const.NAME_PREFIX}_{oid}"
 
     def _create_copy_function(self) -> None:
         self.command.drop_function_if_exists(function=self.function)

--- a/src/psycopack/_tracker.py
+++ b/src/psycopack/_tracker.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 from typing import Iterator
 
-from . import _commands, _cur, _introspect
+from . import _commands, _const, _cur, _introspect
 from . import _psycopg as psycopg
 
 
@@ -210,8 +210,8 @@ class Tracker:
     def _get_tracker_table_name(self) -> str:
         # Manipulate the copy_table name directly to avoid an extra
         # introspection query to find the table oid.
-        oid = self.copy_table.split("repack_")[1]
-        return f"repack_{oid}_tracker"
+        oid = self.copy_table.split(f"{_const.NAME_PREFIX}_")[1]
+        return f"{_const.NAME_PREFIX}_{oid}_tracker"
 
     def _tracker_table_exists(self) -> bool:
         return bool(self.introspector.get_table_oid(table=self.tracker_table))


### PR DESCRIPTION
Prior to this change, the relations involved in the repacking process
were prefixed by the name "repack".

One potential issue is that a particular user looking at the database
schema while the repacking process is happening might be confused about
why those relations exist and what they mean.

This change alters the prefix name to "psycopack". This way, with a more
unique prefix, the unaware user can search for it and find the reason
for these relations to exist.

As an example, the relation names before a swap for table oid 12345
will be:
```
 psycopack_12345                   (copy table)
 psycopack_12345_backfill          (backfill log table)
 psycopack_12345_backfill_id_seq   (id seq of the above)
 psycopack_12345_tracker           (repacking tracker table)
 psycopack_12345_id_seq            (id seq of the above)
```
And after the swap, but before the clean up:
```
 psycopack_12345_backfill          (backfill log table)
 psycopack_12345_backfill_id_seq   (id seq of the above)
 psycopack_12345_tracker           (repacking tracker table)
 psycopack_12345_id_seq            (id seq of the above)
 psycopack_repacked_12345          (original table, now repacked)
```