### PR TITLE
Run coverage on tests folder

### DIFF
--- a/makefile
+++ b/makefile
@@ -33,7 +33,7 @@ test:
 .PHONY:coverage_run
 coverage_run:
 	coverage run --branch \
-	--include=src/psycopack/* \
+	--include=src/psycopack/*,tests/* \
 	--data-file=$(COVERAGE_FILE) \
 	-m pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ DATABASE_NAME = os.getenv("DATABASE_NAME", "test_psycopack")
 def connection() -> Generator[psycopg.Connection, None, None]:
     with _conn.get_db_connection(DATABASE_URL) as conn:
         cur = conn.cursor()
-        if not psycopg.PSYCOPG_3:
+        if not psycopg.PSYCOPG_3:  # pragma: no cover
             # https://github.com/psycopg/psycopg2/issues/941#issuecomment-864025101
             # https://github.com/psycopg/psycopg2/issues/1305#issuecomment-866712961
             cur.execute("ABORT")


### PR DESCRIPTION
Similar to the src/ folder, the tests/ folder can also have dead paths or misconfiguration in test functions or fixtures that may lead to dead tests, or false assumptions about what is being tested.

This change will start looking for lack of coverage on files in the tests/ folder, and should help with finding out what these tests are in the future.

Note: the current coverage job is only run with psycopg 3.