### PR TITLE
Add check against inherited tables

### DIFF
--- a/src/psycopack/__init__.py
+++ b/src/psycopack/__init__.py
@@ -2,11 +2,18 @@
 A customizable way to repack a table using psycopg.
 """
 
-from ._repack import BaseRepackError, Repack, TableDoesNotExist, TableIsEmpty
+from ._repack import (
+    BaseRepackError,
+    InheritedTable,
+    Repack,
+    TableDoesNotExist,
+    TableIsEmpty,
+)
 
 
 __all__ = (
     "BaseRepackError",
+    "InheritedTable",
     "Repack",
     "TableDoesNotExist",
     "TableIsEmpty",

--- a/src/psycopack/_introspect.py
+++ b/src/psycopack/_introspect.py
@@ -229,3 +229,20 @@ class Introspector:
             .as_string(self.conn)
         )
         return bool(self.cur.fetchone())
+
+    def is_inherited_table(self, *, table: str) -> bool:
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                SELECT
+                  1
+                FROM
+                  pg_inherits
+                WHERE
+                  inhrelid = {table}::regclass;
+                """)
+            )
+            .format(table=psycopg.sql.Literal(table))
+            .as_string(self.conn)
+        )
+        return bool(self.cur.fetchone())


### PR DESCRIPTION
Add check against inherited tables

Prior to this change, inherited tables were not being checked against.

We don't have a use case for handling inherited tables at the present,
and as such, it does not make sense to support them for the first relase
of psycopack.

In future, this decision might change and we might be interested in
supporting inherited tables.
