### PR TITLE
Add check against tables with triggers

### DIFF
--- a/src/psycopack/__init__.py
+++ b/src/psycopack/__init__.py
@@ -7,6 +7,7 @@ from ._repack import (
     InheritedTable,
     Repack,
     TableDoesNotExist,
+    TableHasTriggers,
     TableIsEmpty,
 )
 
@@ -16,5 +17,6 @@ __all__ = (
     "InheritedTable",
     "Repack",
     "TableDoesNotExist",
+    "TableHasTriggers",
     "TableIsEmpty",
 )


### PR DESCRIPTION
Add check against tables with triggers
    
There is no present use case for repacking a table that has triggers.
    
This exception will be raised to signal that and prevent tables with
triggers of being repacked mistakenly.
