### PR TITLE
Fix validation error when multiple indexes present

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -47,7 +47,8 @@ def create_table_for_repacking(
             valid_fk INTEGER REFERENCES referred_table(id),
             not_valid_fk INTEGER,
             {table_name} INTEGER,
-            var_maybe_with_exclusion VARCHAR(255)
+            var_maybe_with_exclusion VARCHAR(255),
+            var_with_multiple_idx VARCHAR(10)
         );
     """)
     )
@@ -65,6 +66,17 @@ def create_table_for_repacking(
         ON {table_name} (int_with_long_index_name);
         """)
     )
+
+    cur.execute(
+        f"CREATE INDEX duplicate_idx_1 ON {table_name} (var_with_multiple_idx);"
+    )
+    cur.execute(
+        f"CREATE INDEX duplicate_idx_2 ON {table_name} (var_with_multiple_idx);"
+    )
+    cur.execute(
+        f"CREATE UNIQUE INDEX duplicate_idx_3 ON {table_name} (var_with_multiple_idx);"
+    )
+
     # Index for a column that has the same name as the table.
     cur.execute(f"CREATE INDEX {table_name}_idx ON {table_name} ({table_name});")
     cur.execute(
@@ -126,7 +138,8 @@ def create_table_for_repacking(
             valid_fk,
             not_valid_fk,
             {table_name},
-            var_maybe_with_exclusion
+            var_maybe_with_exclusion,
+            var_with_multiple_idx
         )
         SELECT
             substring(md5(random()::text), 1, 10),
@@ -141,6 +154,7 @@ def create_table_for_repacking(
             (floor(random() * {referred_table_rows}) + 1)::int,
             (floor(random() * {referred_table_rows}) + 1)::int,
             (floor(random() * 10) + 1)::int,
+            substring(md5(random()::text), 1, 10),
             substring(md5(random()::text), 1, 10)
         FROM generate_series(1, {rows});
     """)


### PR DESCRIPTION
Prior to this change, the algorithm to rename indexes (from the copy
table to the original) did not work when the original table had
duplicated indexes (indexes on the same field with the same definition).

The reason, is that the algorithm uses a Python dictionary where the
keys are a stripped-down version of the index definition. That means
that a second index with the same definition would override the existing
key in that dictionary, instead of appending to it.

This change fixes that, by using a list of indexes that have the
particular index definition of the dictionary key, and iterating through
it when renaming indexes.
