### PR TITLE
Assert table must have supported primary key

### DIFF
--- a/src/psycopack/__init__.py
+++ b/src/psycopack/__init__.py
@@ -4,19 +4,25 @@ A customizable way to repack a table using psycopg.
 
 from ._repack import (
     BaseRepackError,
+    CompositePrimaryKey,
     InheritedTable,
+    PrimaryKeyNotFound,
     Repack,
     TableDoesNotExist,
     TableHasTriggers,
     TableIsEmpty,
+    UnsupportedPrimaryKey,
 )
 
 
 __all__ = (
     "BaseRepackError",
+    "CompositePrimaryKey",
     "InheritedTable",
+    "PrimaryKeyNotFound",
     "Repack",
     "TableDoesNotExist",
     "TableHasTriggers",
     "TableIsEmpty",
+    "UnsupportedPrimaryKey",
 )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -11,6 +11,7 @@ def create_table_for_repacking(
     referred_table_rows: int = 10,
     referring_table_rows: int = 10,
     with_exclusion_constraint: bool = False,
+    pk_type: str = "SERIAL",
 ) -> None:
     """
     Creates a table to repack (default: "to_repack") that has:
@@ -31,10 +32,17 @@ def create_table_for_repacking(
     cur.execute(
         f"INSERT INTO not_valid_referred_table (id) SELECT generate_series(1, {referred_table_rows});"
     )
+
+    if "serial" not in pk_type.lower():
+        # Create a sequence manually.
+        seq = f"{table_name}_seq"
+        cur.execute(f"CREATE SEQUENCE {seq};")
+        pk_type = f"{pk_type} DEFAULT NEXTVAL('{seq}')"
+
     cur.execute(
         dedent(f"""
         CREATE TABLE {table_name} (
-            id SERIAL PRIMARY KEY,
+            id {pk_type} PRIMARY KEY,
             var_with_btree VARCHAR(255),
             var_with_pattern_ops VARCHAR(255),
             int_with_check INTEGER CHECK (int_with_check >= 0),


### PR DESCRIPTION
Prior to this change, there was nothing preventing a table with unsupported primary keys (or lack thereof), to run through the psycopack process. The process would fail unexpectedly in the table setup stage, however.

This change makes sure that tables with unsupported primary keys do not even start the psycopack process.