### PR TITLE
Generalise pk column name

### DIFF
--- a/src/psycopack/_introspect.py
+++ b/src/psycopack/_introspect.py
@@ -82,25 +82,28 @@ class Introspector:
         )
         return [r[0] for r in self.cur.fetchall()]
 
-    def get_min_and_max_id(self, *, table: str) -> tuple[int, int]:
+    def get_min_and_max_pk(self, *, table: str, pk_column: str) -> tuple[int, int]:
         self.cur.execute(
             psycopg.sql.SQL(
                 dedent("""
                 SELECT
-                  MIN(id) AS min_id,
-                  MAX(id) AS max_id
+                  MIN({pk_column}) AS min_pk,
+                  MAX({pk_column}) AS max_pk
                 FROM {table};
                 """)
             )
-            .format(table=psycopg.sql.Identifier(table))
+            .format(
+                table=psycopg.sql.Identifier(table),
+                pk_column=psycopg.sql.Identifier(pk_column),
+            )
             .as_string(self.conn)
         )
         result = self.cur.fetchone()
         assert result is not None
-        min_id, max_id = result
-        assert isinstance(min_id, int)
-        assert isinstance(max_id, int)
-        return min_id, max_id
+        min_pk, max_pk = result
+        assert isinstance(min_pk, int)
+        assert isinstance(max_pk, int)
+        return min_pk, max_pk
 
     def get_index_def(self, *, table: str) -> list[Index]:
         self.cur.execute(

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -12,6 +12,7 @@ def create_table_for_repacking(
     referring_table_rows: int = 10,
     with_exclusion_constraint: bool = False,
     pk_type: str = "SERIAL",
+    pk_name: str = "id",
 ) -> None:
     """
     Creates a table to repack (default: "to_repack") that has:
@@ -42,7 +43,7 @@ def create_table_for_repacking(
     cur.execute(
         dedent(f"""
         CREATE TABLE {table_name} (
-            id {pk_type} PRIMARY KEY,
+            {pk_name} {pk_type} PRIMARY KEY,
             var_with_btree VARCHAR(255),
             var_with_pattern_ops VARCHAR(255),
             int_with_check INTEGER CHECK (int_with_check >= 0),
@@ -171,13 +172,13 @@ def create_table_for_repacking(
         dedent(f"""
         CREATE TABLE referring_table (
             id SERIAL PRIMARY KEY,
-            {table_name}_id INTEGER REFERENCES {table_name}(id)
+            {table_name}_{pk_name} INTEGER REFERENCES {table_name}({pk_name})
         );
     """)
     )
     cur.execute(
         dedent(f"""
-        INSERT INTO referring_table ({table_name}_id)
+        INSERT INTO referring_table ({table_name}_{pk_name})
         SELECT generate_series(1, {referring_table_rows});
     """)
     )
@@ -185,21 +186,21 @@ def create_table_for_repacking(
         dedent(f"""
         CREATE TABLE not_valid_referring_table (
             id SERIAL PRIMARY KEY,
-            {table_name}_id INTEGER
+            {table_name}_{pk_name} INTEGER
         );
     """)
     )
     cur.execute(
         dedent(f"""
         ALTER TABLE not_valid_referring_table ADD CONSTRAINT not_valid_referring
-            FOREIGN KEY ({table_name}_id)
-            REFERENCES {table_name}(id)
+            FOREIGN KEY ({table_name}_{pk_name})
+            REFERENCES {table_name}({pk_name})
             NOT VALID;
     """)
     )
     cur.execute(
         dedent(f"""
-        INSERT INTO not_valid_referring_table ({table_name}_id)
+        INSERT INTO not_valid_referring_table ({table_name}_{pk_name})
         SELECT generate_series(1, {referring_table_rows});
     """)
     )


### PR DESCRIPTION
Prior to this change, the code enforced a hardcoded requirement for the primary key column to be named "id".

This limitation is unecessary. The primary key column can have any arbitrary name.

This change introduces an instance variable (self.pk_column) for the primary key, which is determined through introspection queries.

This change allows for all the introspection queries and commands that have the hardcoded requirement above to be updated to use the instance variable instead.