### PR TITLE
Make backfill table handle bigint values

### DIFF
--- a/src/psycopack/_commands.py
+++ b/src/psycopack/_commands.py
@@ -110,7 +110,7 @@ class Command:
         self.cur.execute(
             psycopg.sql.SQL(
                 dedent("""
-                CREATE OR REPLACE FUNCTION {function}(INTEGER, INTEGER)
+                CREATE OR REPLACE FUNCTION {function}(BIGINT, BIGINT)
                 RETURNS VOID AS $$
 
                   INSERT INTO {table_to}
@@ -195,8 +195,8 @@ class Command:
                 dedent("""
                 CREATE TABLE {table} (
                   id SERIAL PRIMARY KEY,
-                  batch_start INT,
-                  batch_end INT,
+                  batch_start BIGINT,
+                  batch_end BIGINT,
                   finished BOOLEAN
                 );
                 """)


### PR DESCRIPTION
Prior to this change, the backfill table looked like this:
```sql
  CREATE TABLE ... (
    id SERIAL PRIMARY KEY,
    batch_start INT,
    batch_end INT,
    finished BOOLEAN
```
That meant that tables with large integer values (greater than a unsigined 32bit integer), wouldn't fit in the table.

Local experimentation proved that psycopg would raise the following exception when this situation was attemped:
```
  E           psycopg.errors.NumericValueOutOfRange: integer out of range
```
This change fixes this problem, by increasing the batch_start and batch_end data types to be big integers.

The signature for the repacking function also had to be updated so that the batch inserts (which call that function) wouldn't fail.