### PR TITLE
Handle tables without pk sequence

### DIFF
--- a/src/psycopack/_introspect.py
+++ b/src/psycopack/_introspect.py
@@ -385,6 +385,9 @@ class Introspector:
             result = self.cur.fetchone()
             assert result is not None
             seq_def = result[0]
+            if seq_def is None:
+                return ""
+
             assert isinstance(seq_def, str)
             # The seq_def variable looks something like:
             #  nextval('psycopack_2999727_id_seq'::regclass)

--- a/src/psycopack/_repack.py
+++ b/src/psycopack/_repack.py
@@ -301,7 +301,7 @@ class Repack:
                 always=(pk_info.identity_type == "a"),
                 pk_column=self.pk_column,
             )
-        else:
+        elif self.introspector.get_pk_sequence_name(table=self.table):
             # Create a new sequence for the copied table's id column so that it
             # does not depend on the original's one. Otherwise, we wouldn't be
             # able to delete the original table after the repack process is
@@ -539,9 +539,10 @@ class Repack:
                     table=self.table, trigger=self.trigger
                 )
                 self.command.drop_function_if_exists(function=self.function)
-                self.command.swap_pk_sequence_name(
-                    first_table=self.table, second_table=self.copy_table
-                )
+                if self.introspector.get_pk_sequence_name(table=self.table):
+                    self.command.swap_pk_sequence_name(
+                        first_table=self.table, second_table=self.copy_table
+                    )
                 self.command.rename_table(
                     table_from=self.table, table_to=self.repacked_name
                 )
@@ -590,9 +591,10 @@ class Repack:
                 trigger=self.repacked_trigger,
             )
             self.command.drop_function_if_exists(function=self.repacked_function)
-            self.command.swap_pk_sequence_name(
-                first_table=self.table, second_table=self.repacked_name
-            )
+            if self.introspector.get_pk_sequence_name(table=self.table):
+                self.command.swap_pk_sequence_name(
+                    first_table=self.table, second_table=self.repacked_name
+                )
             self.command.rename_table(table_from=self.table, table_to=self.copy_table)
             self.command.rename_table(
                 table_from=self.repacked_name, table_to=self.table


### PR DESCRIPTION
Prior to this change, the psycopack process was assuming the primary key
would have a sequence to back it up.

This is not necessarily true, as the user might decide to insert ids
manually into the table and keep track of them in any arbitrary way.

This may not be a realistic scenario for most tables that will be
processed by psycopack, but it's still worth handling.

This change skips the parts of the code that where engaging with primary
key sequences.
