### PR TITLE
Add post-backfill batch callback

### DIFF
--- a/src/psycopack/__init__.py
+++ b/src/psycopack/__init__.py
@@ -3,6 +3,7 @@ A customizable way to repack a table using psycopg.
 """
 
 from ._repack import (
+    BackfillBatch,
     BaseRepackError,
     CompositePrimaryKey,
     InheritedTable,
@@ -17,6 +18,7 @@ from ._repack import (
 
 
 __all__ = (
+    "BackfillBatch",
     "BaseRepackError",
     "CompositePrimaryKey",
     "InheritedTable",


### PR DESCRIPTION
Add post-backfill batch callback

Prior to this change, once the psycopack process started backfilling a
table there was no feedback mechanism for the caller to get information
about how the backfill was performing.

This change introduces a new argument (post_backfill_batch_callback) to
the Repack class.

This new argument allows a caller to pass a callback function that will
be called each time the backfill for a batch is finished.

This allows for better instrumentation. For example, the caller might
want to programmatically push metrics on how the progress of the
Repack backfill is going on their production environment so that they
can visualise this data in a dashboard of their choice.
