### PR TITLE
Add lock timeouts

### DIFF
--- a/src/psycopack/__init__.py
+++ b/src/psycopack/__init__.py
@@ -15,12 +15,14 @@ from ._repack import (
     TableIsEmpty,
     UnsupportedPrimaryKey,
 )
+from ._tracker import FailureDueToLockTimeout
 
 
 __all__ = (
     "BackfillBatch",
     "BaseRepackError",
     "CompositePrimaryKey",
+    "FailureDueToLockTimeout",
     "InheritedTable",
     "InvalidPrimaryKeyTypeForConversion",
     "PrimaryKeyNotFound",

--- a/src/psycopack/_commands.py
+++ b/src/psycopack/_commands.py
@@ -1,3 +1,4 @@
+import datetime
 import hashlib
 from contextlib import contextmanager
 from textwrap import dedent
@@ -153,6 +154,7 @@ class Command:
         table_to: str,
         pk_column: str,
     ) -> None:
+        # Note: takes a ShareRowExclusiveLock on the table_from.
         self.cur.execute(
             psycopg.sql.SQL(
                 dedent("""
@@ -347,6 +349,7 @@ class Command:
         )
 
     def rename_index(self, *, idx_from: str, idx_to: str) -> None:
+        # Note: Takes a ShareUpdateExclusiveLock on idx_from
         self.cur.execute(
             psycopg.sql.SQL("ALTER INDEX {idx_from} RENAME TO {idx_to};")
             .format(
@@ -446,3 +449,12 @@ class Command:
         self.cur.execute("BEGIN;")
         yield
         self.cur.execute("COMMIT;")
+
+    @contextmanager
+    def lock_timeout(self, timeout: datetime.timedelta) -> Iterator[None]:
+        timeout_in_ms = int(timeout.total_seconds() * 1000)
+        set_sql = f"SET lock_timeout = {timeout_in_ms};"
+        reset_sql = "SET lock_timeout TO DEFAULT;"
+        self.cur.execute(set_sql)
+        yield
+        self.cur.execute(reset_sql)

--- a/src/psycopack/_psycopg.py
+++ b/src/psycopack/_psycopg.py
@@ -5,13 +5,14 @@ Support package to make sure psycopack works with either psycopg2 or psycopg
 PSYCOPG_3 = False
 
 try:
-    from psycopg import Connection, Cursor, connect, sql
+    from psycopg import Connection, Cursor, connect, errors, sql
 
     PSYCOPG_3 = True
 except ImportError:  # pragma: no cover
     try:
         from psycopg2 import (  # type: ignore[no-redef, assignment] # noqa: F401
             connect,
+            errors,
             sql,
         )
         from psycopg2.extensions import (  # type: ignore[assignment]
@@ -28,4 +29,5 @@ __all__ = (
     "PSYCOPG_3",
     "connect",
     "sql",
+    "errors",
 )

--- a/tests/test_repack.py
+++ b/tests/test_repack.py
@@ -6,6 +6,7 @@ import pytest
 from psycopack import (
     BackfillBatch,
     CompositePrimaryKey,
+    FailureDueToLockTimeout,
     InheritedTable,
     InvalidPrimaryKeyTypeForConversion,
     PrimaryKeyNotFound,
@@ -1310,3 +1311,108 @@ def test_when_post_backfill_batch_callback_is_passed(
         BackfillBatch(id=3, start=51, end=75),
         BackfillBatch(id=4, start=76, end=100),
     ]
+
+
+def test_repeat_stage_when_lock_timeout(connection: _psycopg.Connection) -> None:
+    with connection.cursor() as cur:
+        if not _psycopg.PSYCOPG_3:  # pragma: no cover
+            # https://github.com/psycopg/psycopg2/issues/941#issuecomment-864025101
+            # https://github.com/psycopg/psycopg2/issues/1305#issuecomment-866712961
+            # TODO: wrap the connection so that connection.cursor() doesn't
+            # start in a transaction. Else, this test will fail.
+            cur.execute("ABORT;")
+
+        factories.create_table_for_repacking(
+            connection=connection,
+            cur=cur,
+            table_name="to_repack",
+            rows=100,
+        )
+        table_before = _collect_table_info(table="to_repack", connection=connection)
+        repack = Repack(
+            table="to_repack",
+            batch_size=1,
+            conn=connection,
+            cur=cur,
+        )
+
+        def side_effect(*args: object, **kwargs: object) -> None:
+            repack.cur.execute("ABORT;")
+            raise _psycopg.errors.LockNotAvailable(
+                "canceling statement due to lock timeout"
+            )
+
+        # Pre-validation only uses introspection queries. There's no need for
+        # lock timeouts there.
+        repack.pre_validate()
+
+        # Setting up the copy relations may time out (specially the trigger).
+        with mock.patch.object(repack.command, "create_copy_trigger") as mocked:
+            mocked.side_effect = side_effect
+            with pytest.raises(FailureDueToLockTimeout):
+                repack.setup_repacking()
+
+        # It can be called again successfully as the function is idempotent and
+        # reentrant.
+        repack.setup_repacking()
+
+        # Backfill only performs reads and writes. There's no need for lock
+        # timeouts here.
+        repack.backfill()
+
+        # Syncing the schemas will involve firing multiple DDLs that may time
+        # out.
+        with mock.patch.object(
+            repack.command, "create_unique_constraint_using_idx"
+        ) as mocked:
+            mocked.side_effect = side_effect
+            with pytest.raises(FailureDueToLockTimeout):
+                repack.sync_schemas()
+
+        # It can be called again successfully as the function is idempotent and
+        # reentrant.
+        repack.sync_schemas()
+
+        # Swapping also has many DDLs that may time out as it is moving the
+        # tables around.
+        with mock.patch.object(repack.command, "rename_table") as mocked:
+            mocked.side_effect = side_effect
+            with pytest.raises(FailureDueToLockTimeout):
+                repack.swap()
+
+        # It can be called again successfully as the function is idempotent and
+        # reentrant (it also happens inside a transaction).
+        repack.swap()
+
+        # Reverting the swap is the same as the swap but with the opposite
+        # relations.
+        with mock.patch.object(repack.command, "rename_table") as mocked:
+            mocked.side_effect = side_effect
+            with pytest.raises(_psycopg.errors.LockNotAvailable):
+                repack.revert_swap()
+
+        # It can be called again successfully as the function is idempotent and
+        # reentrant (it also happens inside a transaction).
+        repack.revert_swap()
+
+        # Swap again so that we can proceed to the next stage.
+        repack.swap()
+
+        # The clean-up function also produces DDLs when renaming idx and
+        # constraints and those DDLs can time out.
+        with mock.patch.object(repack.command, "rename_index") as mocked:
+            mocked.side_effect = side_effect
+            with pytest.raises(FailureDueToLockTimeout):
+                repack.clean_up()
+
+        # It can be called again successfully as the function is idempotent and
+        # reentrant (it also happens inside a transaction).
+        repack.clean_up()
+
+        table_after = _collect_table_info(table="to_repack", connection=connection)
+        _assert_repack(
+            table_before=table_before,
+            table_after=table_after,
+            repack=repack,
+            cur=cur,
+        )


### PR DESCRIPTION
## Introduce lock timeouts

Prior to this change, psycopack had no consideration for lock timeouts.

This means that if the underlying table being psycopacked was busy, the
lock queue would be haulted when psycopack AT commands tried to acquire
an access exclusive lock on the table. This would potentially result in
a outage.

This change introduces a configurable lock timeout parameter, so that
the user can control the behaviour of how long to wait to acquire a lock
before bailing out.

This also introduces room for more failures and interruptions during the
process. But considering that each stage is idempotent and reentrant,
which has been fixed in some of the commits in this PR, the user should
be able to run the same stage again during less-busy hours.

The timeout strategy for each stage is as follows:

- pre_setup: Doesn't need lock timeouts as it only fires introspection
  queries.
- setup: Creates the copy relations, the trigger, and the function. The
  whole process is behind the lock_timeout ctx manager.
- backfill: Only performs reads and writes, so there's no use for lock
  timeouts here
- sync_schemas: The index creation is particular, and requires
  lock_timeouts set to 0, apart from that, the other functions should
  all obey the set lock_timeout value.
- swap/revert_swap/clean_up: since these operations are all done within
  a transaction, the lock_timeout value is applied on it.
