### PR TITLE
Expose get_db_connection publicly

### DIFF
--- a/src/psycopack/__init__.py
+++ b/src/psycopack/__init__.py
@@ -2,6 +2,7 @@
 A customizable way to repack a table using psycopg.
 """
 
+from ._conn import get_db_connection
 from ._introspect import BackfillBatch
 from ._repack import (
     BaseRepackError,
@@ -45,4 +46,5 @@ __all__ = (
     "TableHasTriggers",
     "TableIsEmpty",
     "UnsupportedPrimaryKey",
+    "get_db_connection",
 )


### PR DESCRIPTION
Prior to this change, a Psycopack user interfacing with the Python API would have to call Psycopack in such way:
```py
  with _conn.get_db_connection(DATABASE_URL) as conn:
      with conn.cursor() as cur:
          repack = Repack(
              conn=conn,
              cur=cur,
              ...
          )
          repack.full()
```
This isn't ideal because the _conn module is private.

There is also no option for the user to directly get their connection and cursor from psycopg2 or psycopg (3), unless they don't care about type annotations (in which case they already can).

This commit exposes get_db_connection publicly so that users can get type-annotated cursors and connections.