### PR TITLE
Improve idempotency

### DIFF
--- a/src/psycopack/_const.py
+++ b/src/psycopack/_const.py
@@ -1,2 +1,3 @@
 NAME_PREFIX = "psycopack"
 REPACKED_NAME_PREFIX = "psycopack_repacked"
+PSYCOPACK_REGISTRY = "psycopack_registry"

--- a/src/psycopack/_registry.py
+++ b/src/psycopack/_registry.py
@@ -1,0 +1,216 @@
+import dataclasses
+from textwrap import dedent
+
+from . import _commands, _const, _cur, _introspect
+from . import _psycopg as psycopg
+
+
+@dataclasses.dataclass
+class RegistryRow:
+    original_table: str
+    copy_table: str
+    id_seq: str
+    function: str
+    trigger: str
+    backfill_log: str
+    repacked_name: str
+    repacked_function: str
+    repacked_trigger: str
+
+
+class Registry:
+    def __init__(
+        self,
+        *,
+        conn: psycopg.Connection,
+        cur: _cur.LoggedCursor,
+        introspector: _introspect.Introspector,
+        command: _commands.Command,
+        schema: str,
+        table: str,
+    ) -> None:
+        self.conn = conn
+        self.cur = cur
+        self.introspector = introspector
+        self.schema = schema
+        self.table = table
+
+    def get_registry_row(self) -> RegistryRow:
+        row = self._get_row_from_registry_table()
+        if row:
+            return row
+
+        oid = self.introspector.get_table_oid(table=self.table)
+        assert oid is not None
+
+        copy_table = f"{_const.NAME_PREFIX}_{oid}"
+        id_seq = f"{copy_table}_id_seq"
+        function = f"{copy_table}_fun"
+        trigger = f"{copy_table}_tgr"
+        backfill_log = f"{copy_table}_backfill"
+        repacked_name = copy_table.replace(
+            _const.NAME_PREFIX, _const.REPACKED_NAME_PREFIX
+        )
+        repacked_function = function.replace(
+            _const.NAME_PREFIX, _const.REPACKED_NAME_PREFIX
+        )
+        repacked_trigger = trigger.replace(
+            _const.NAME_PREFIX, _const.REPACKED_NAME_PREFIX
+        )
+        row = RegistryRow(
+            original_table=self.table,
+            copy_table=copy_table,
+            id_seq=id_seq,
+            function=function,
+            trigger=trigger,
+            backfill_log=backfill_log,
+            repacked_name=repacked_name,
+            repacked_function=repacked_function,
+            repacked_trigger=repacked_trigger,
+        )
+        self._insert_row_into_registry(row=row)
+        return row
+
+    def _get_row_from_registry_table(self) -> RegistryRow | None:
+        self._ensure_registry_table_exists()
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                SELECT
+                  original_table,
+                  copy_table,
+                  id_seq,
+                  function,
+                  trigger,
+                  backfill_log,
+                  repacked_name,
+                  repacked_function,
+                  repacked_trigger
+                FROM
+                  {schema}.{registry_table}
+                WHERE
+                  original_table = {original_table}
+                LIMIT 1;
+                """)
+            )
+            .format(
+                schema=psycopg.sql.Identifier(self.schema),
+                registry_table=psycopg.sql.Identifier(_const.PSYCOPACK_REGISTRY),
+                original_table=psycopg.sql.Literal(self.table),
+            )
+            .as_string(self.conn)
+        )
+        result = self.cur.fetchone()
+        if not result:
+            return None
+        return RegistryRow(
+            original_table=result[0],
+            copy_table=result[1],
+            id_seq=result[2],
+            function=result[3],
+            trigger=result[4],
+            backfill_log=result[5],
+            repacked_name=result[6],
+            repacked_function=result[7],
+            repacked_trigger=result[8],
+        )
+
+    def _ensure_registry_table_exists(self) -> None:
+        if self._registry_table_exists():
+            return
+        self._create_registry_table()
+
+    def _registry_table_exists(self) -> bool:
+        return bool(self.introspector.get_table_oid(table=_const.PSYCOPACK_REGISTRY))
+
+    def _create_registry_table(self) -> None:
+        self.cur.execute(
+            psycopg.sql.SQL(
+                # - The maximum length for a Postgres identifier is 63.
+                # - All names must be unique. Else, having the same name for
+                #   two different tables being repacked would be ambiguous.
+                dedent("""
+                CREATE TABLE {schema}.{registry_table} (
+                  original_table VARCHAR(63) NOT NULL UNIQUE,
+                  copy_table VARCHAR(63) NOT NULL UNIQUE,
+                  id_seq VARCHAR(63) NOT NULL UNIQUE,
+                  function VARCHAR(63) NOT NULL UNIQUE,
+                  trigger VARCHAR(63) NOT NULL UNIQUE,
+                  backfill_log VARCHAR(63) NOT NULL UNIQUE,
+                  repacked_name VARCHAR(63) NOT NULL UNIQUE,
+                  repacked_function VARCHAR(63) NOT NULL UNIQUE,
+                  repacked_trigger VARCHAR(63) NOT NULL UNIQUE
+                );
+                """)
+            )
+            .format(
+                registry_table=psycopg.sql.Identifier(_const.PSYCOPACK_REGISTRY),
+                schema=psycopg.sql.Identifier(self.schema),
+            )
+            .as_string(self.conn)
+        )
+
+    def _insert_row_into_registry(self, row: RegistryRow) -> None:
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                INSERT INTO
+                  {schema}.{registry_table}
+                  (
+                    original_table,
+                    copy_table,
+                    id_seq,
+                    function,
+                    trigger,
+                    backfill_log,
+                    repacked_name,
+                    repacked_function,
+                    repacked_trigger
+                  )
+                VALUES
+                  (
+                    {original_table},
+                    {copy_table},
+                    {id_seq},
+                    {function},
+                    {trigger},
+                    {backfill_log},
+                    {repacked_name},
+                    {repacked_function},
+                    {repacked_trigger}
+                  );
+                """)
+            )
+            .format(
+                registry_table=psycopg.sql.Identifier(_const.PSYCOPACK_REGISTRY),
+                schema=psycopg.sql.Identifier(self.schema),
+                original_table=psycopg.sql.Literal(row.original_table),
+                copy_table=psycopg.sql.Literal(row.copy_table),
+                id_seq=psycopg.sql.Literal(row.id_seq),
+                function=psycopg.sql.Literal(row.function),
+                trigger=psycopg.sql.Literal(row.trigger),
+                backfill_log=psycopg.sql.Literal(row.backfill_log),
+                repacked_name=psycopg.sql.Literal(row.repacked_name),
+                repacked_function=psycopg.sql.Literal(row.repacked_function),
+                repacked_trigger=psycopg.sql.Literal(row.repacked_trigger),
+            )
+            .as_string(self.conn)
+        )
+
+    def delete_row_for(self, *, table: str) -> None:
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                DELETE FROM
+                  {schema}.{registry_table}
+                WHERE
+                  original_table = {original_table};
+                """)
+            )
+            .format(
+                schema=psycopg.sql.Identifier(self.schema),
+                registry_table=psycopg.sql.Identifier(_const.PSYCOPACK_REGISTRY),
+                original_table=psycopg.sql.Literal(table),
+            )
+            .as_string(self.conn)
+        )

--- a/src/psycopack/_repack.py
+++ b/src/psycopack/_repack.py
@@ -7,7 +7,7 @@ import datetime
 import typing
 from collections import defaultdict
 
-from . import _commands, _const, _cur, _identifiers, _introspect, _tracker
+from . import _commands, _cur, _identifiers, _introspect, _registry, _tracker
 from . import _psycopg as psycopg
 
 
@@ -156,23 +156,26 @@ class Repack:
         self.post_backfill_batch_callback = post_backfill_batch_callback
         self.lock_timeout = lock_timeout
         self.convert_pk_to_bigint = convert_pk_to_bigint
-        # Names for the copy table.
-        self.copy_table = self._get_copy_table_name()
-        self.id_seq = f"{self.copy_table}_id_seq"
-        self.function = f"{self.copy_table}_fun"
-        self.trigger = f"{self.copy_table}_tgr"
-        self.backfill_log = f"{self.copy_table}_backfill"
 
+        # Names for psycopack objects are stored in the Registry
+        self.registry = _registry.Registry(
+            conn=self.conn,
+            cur=self.cur,
+            schema=schema,
+            introspector=self.introspector,
+            command=self.command,
+            table=table,
+        )
+        registry_row = self.registry.get_registry_row()
+        self.copy_table = registry_row.copy_table
+        self.id_seq = registry_row.id_seq
+        self.function = registry_row.function
+        self.trigger = registry_row.trigger
+        self.backfill_log = registry_row.backfill_log
         # Names after the original table once it has been repacked and swapped.
-        self.repacked_name = self.copy_table.replace(
-            _const.NAME_PREFIX, _const.REPACKED_NAME_PREFIX
-        )
-        self.repacked_function = self.function.replace(
-            _const.NAME_PREFIX, _const.REPACKED_NAME_PREFIX
-        )
-        self.repacked_trigger = self.trigger.replace(
-            _const.NAME_PREFIX, _const.REPACKED_NAME_PREFIX
-        )
+        self.repacked_name = registry_row.repacked_name
+        self.repacked_function = registry_row.repacked_function
+        self.repacked_trigger = registry_row.repacked_trigger
 
         self.tracker = _tracker.Tracker(
             table=self.table,
@@ -493,6 +496,7 @@ class Repack:
 
                 self.command.drop_table_if_exists(table=self.repacked_name)
                 self.command.drop_table_if_exists(table=self.backfill_log)
+                self.registry.delete_row_for(table=self.table)
 
     def reset(self) -> None:
         current_stage = self.tracker.get_current_stage()
@@ -592,12 +596,6 @@ class Repack:
                 ),
                 definition=constraint.definition,
             )
-
-    def _get_copy_table_name(self) -> str:
-        oid = self.introspector.get_table_oid(table=self.table)
-        if oid is None:
-            raise TableDoesNotExist(f'Table "{self.table}" does not exist.')
-        return f"{_const.NAME_PREFIX}_{oid}"
 
     def _create_copy_function(self) -> None:
         self.command.drop_function_if_exists(function=self.function)

--- a/tests/test_repack.py
+++ b/tests/test_repack.py
@@ -23,6 +23,7 @@ from psycopack import (
     TableHasTriggers,
     TableIsEmpty,
     UnsupportedPrimaryKey,
+    _const,
     _cur,
     _introspect,
     _psycopg,
@@ -137,6 +138,13 @@ def _assert_repack(
 
     # The tracker table itself will also be deleted after the clean up process.
     assert repack.introspector.get_table_oid(table=repack.tracker.tracker_table) is None
+
+    # The row in the Registry will also be removed after the process is done.
+    cur.execute(
+        f"SELECT 1 FROM {repack.schema}.{_const.PSYCOPACK_REGISTRY} "
+        f"WHERE original_table = '{repack.table}';"
+    )
+    assert cur.fetchone() is None
 
 
 def _assert_reset(repack: Repack, cur: _psycopg.Cursor) -> None:
@@ -1877,7 +1885,6 @@ def test_user_with_bare_minimum_permissions(connection: _psycopg.Connection) -> 
         )
 
 
-@pytest.mark.xfail
 def test_when_repack_is_reinstantiated_after_swapping(
     connection: _psycopg.Connection,
 ) -> None:


### PR DESCRIPTION
# Improve Idempotency

The changes in this PR are mainly to fix a bug.
In summary, the bug case can be explained as such:
    
      - The user runs the swap() command.
      - Now the copy table has been swapped with the original.
      - Their script crashes and they have to re-instantiate the Repack class.
      - The new Repack instance thinks that the recently-swapped class is the
        original.
      - The instance can't find any existing Psycopack objects, because they are
        all named after the OID of the original table.
      - Psycopack can't finish the process because it thinks the process never
        started.
