### PR TITLE
Rename Repack class to Psycopack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# psycopack
+# Psycopack

--- a/src/psycopack/__init__.py
+++ b/src/psycopack/__init__.py
@@ -5,7 +5,7 @@ A customizable way to repack a table using psycopg.
 from ._conn import get_db_connection
 from ._introspect import BackfillBatch
 from ._repack import (
-    BaseRepackError,
+    BasePsycopackError,
     CompositePrimaryKey,
     InheritedTable,
     InvalidIndexes,
@@ -16,8 +16,8 @@ from ._repack import (
     NoReferringTableOwnership,
     NotTableOwner,
     PrimaryKeyNotFound,
+    Psycopack,
     ReferringForeignKeyInDifferentSchema,
-    Repack,
     TableDoesNotExist,
     TableHasTriggers,
     TableIsEmpty,
@@ -28,7 +28,7 @@ from ._tracker import FailureDueToLockTimeout
 
 __all__ = (
     "BackfillBatch",
-    "BaseRepackError",
+    "BasePsycopackError",
     "CompositePrimaryKey",
     "FailureDueToLockTimeout",
     "InheritedTable",
@@ -41,7 +41,7 @@ __all__ = (
     "NotTableOwner",
     "PrimaryKeyNotFound",
     "ReferringForeignKeyInDifferentSchema",
-    "Repack",
+    "Psycopack",
     "TableDoesNotExist",
     "TableHasTriggers",
     "TableIsEmpty",

--- a/src/psycopack/_registry.py
+++ b/src/psycopack/_registry.py
@@ -128,7 +128,8 @@ class Registry:
             psycopg.sql.SQL(
                 # - The maximum length for a Postgres identifier is 63.
                 # - All names must be unique. Else, having the same name for
-                #   two different tables being repacked would be ambiguous.
+                #   two different tables being processed by Psycopack would be
+                #   ambiguous.
                 dedent("""
                 CREATE TABLE {schema}.{registry_table} (
                   original_table VARCHAR(63) NOT NULL UNIQUE,

--- a/src/psycopack/_repack.py
+++ b/src/psycopack/_repack.py
@@ -11,67 +11,67 @@ from . import _commands, _cur, _identifiers, _introspect, _registry, _tracker
 from . import _psycopg as psycopg
 
 
-class BaseRepackError(Exception):
+class BasePsycopackError(Exception):
     pass
 
 
-class TableDoesNotExist(BaseRepackError):
+class TableDoesNotExist(BasePsycopackError):
     pass
 
 
-class TableIsEmpty(BaseRepackError):
+class TableIsEmpty(BasePsycopackError):
     pass
 
 
-class InheritedTable(BaseRepackError):
+class InheritedTable(BasePsycopackError):
     pass
 
 
-class TableHasTriggers(BaseRepackError):
+class TableHasTriggers(BasePsycopackError):
     pass
 
 
-class PrimaryKeyNotFound(BaseRepackError):
+class PrimaryKeyNotFound(BasePsycopackError):
     pass
 
 
-class CompositePrimaryKey(BaseRepackError):
+class CompositePrimaryKey(BasePsycopackError):
     pass
 
 
-class UnsupportedPrimaryKey(BaseRepackError):
+class UnsupportedPrimaryKey(BasePsycopackError):
     pass
 
 
-class InvalidPrimaryKeyTypeForConversion(BaseRepackError):
+class InvalidPrimaryKeyTypeForConversion(BasePsycopackError):
     pass
 
 
-class InvalidStageForReset(BaseRepackError):
+class InvalidStageForReset(BasePsycopackError):
     pass
 
 
-class InvalidIndexes(BaseRepackError):
+class InvalidIndexes(BasePsycopackError):
     pass
 
 
-class ReferringForeignKeyInDifferentSchema(BaseRepackError):
+class ReferringForeignKeyInDifferentSchema(BasePsycopackError):
     pass
 
 
-class NoCreateAndUsagePrivilegeOnSchema(BaseRepackError):
+class NoCreateAndUsagePrivilegeOnSchema(BasePsycopackError):
     pass
 
 
-class NotTableOwner(BaseRepackError):
+class NotTableOwner(BasePsycopackError):
     pass
 
 
-class NoReferringTableOwnership(BaseRepackError):
+class NoReferringTableOwnership(BasePsycopackError):
     pass
 
 
-class NoReferencesPrivilege(BaseRepackError):
+class NoReferencesPrivilege(BasePsycopackError):
     pass
 
 
@@ -81,20 +81,21 @@ class PostBackfillBatchCallback(typing.Protocol):
     ) -> None: ...  # pragma: no cover
 
 
-class Repack:
+class Psycopack:
     """
-    Class for operating a full table repack.
+    Class for operating a full table copy-and-swap (Psycopack) process.
 
     This class can be used in two different ways:
 
-    - Calling Repack(...).full(): This will operate a repack from beginning to
-      end without any intervention. This is a good choice if all you want is to
-      repack a table.
+    - Calling Psycopack(...).full(): This will operate a repack from beginning
+      to end without any intervention. This is a good choice if all you want is
+      to repack a table.
 
     - Calling each of the public functions individually to pace-out or
       customise the repacking process. The public functions are:
 
-        1. pre_validate(): Checks if the table can be repacked at all.
+        1. pre_validate(): Checks if the table can be processed by Psycopack at
+           all.
         2. setup_repacking(): Create the copy function, trigger, table, and
            also setup the backfill log table. The backfill log table controls
            the backfilling process. If you want to customise the layout of
@@ -172,7 +173,7 @@ class Repack:
         self.function = registry_row.function
         self.trigger = registry_row.trigger
         self.backfill_log = registry_row.backfill_log
-        # Names after the original table once it has been repacked and swapped.
+        # Names after the original table once it has been swapped.
         self.repacked_name = registry_row.repacked_name
         self.repacked_function = registry_row.repacked_function
         self.repacked_trigger = registry_row.repacked_trigger

--- a/src/psycopack/_tracker.py
+++ b/src/psycopack/_tracker.py
@@ -32,11 +32,11 @@ class StageAlreadyFinished(TrackerException):
     pass
 
 
-class InvalidRepackingSetup(TrackerException):
+class InvalidPsycopackSetup(TrackerException):
     pass
 
 
-class InvalidRepackingStep(TrackerException):
+class InvalidPsycopackStep(TrackerException):
     pass
 
 
@@ -65,14 +65,14 @@ class Stage(enum.Enum):
 
 class Tracker:
     """
-    A class to keep track of where in the repacking process a table is.
+    A class to keep track of where in the Psycopack process a table is.
 
     It should be used via the two public methods:
 
       1. `track` (context manager): used to verify if a stage pre-condition
          is valid, and to log the stage completion once it has exited.
 
-      2. `get_current_stage`: used to verify which stage the repacking process
+      2. `get_current_stage`: used to verify which stage the Psycopack process
          is currently at.
     """
 
@@ -134,9 +134,9 @@ class Tracker:
             return
 
         if stage and (stage != self.initial_stage):
-            raise InvalidRepackingSetup(
-                f"The repacking process should be initiated by the "
-                f"{self.initial_stage} stage. Tried to start repacking with "
+            raise InvalidPsycopackSetup(
+                f"The Psycopack process should be initiated by the "
+                f"{self.initial_stage} stage. Tried to start Psycopack with "
                 f"{stage} instead."
             )
 
@@ -158,7 +158,7 @@ class Tracker:
     def _validate_stage_in_right_sequence(self, *, stage: Stage) -> None:
         unfinished_stage = self._get_unfinished_stage()
         if stage != unfinished_stage:
-            raise InvalidRepackingStep(
+            raise InvalidPsycopackStep(
                 f"Cannot run {stage} if the current stage is {unfinished_stage}."
             )
 
@@ -209,8 +209,8 @@ class Tracker:
                 self._set_stage(stage_from=stage, stage_to=Stage.CLEAN_UP)
                 return
             case Stage.CLEAN_UP:
-                # Repacking is done. We have to drop the tracker table as well
-                # to not leave any repacking relations behind.
+                # Psycopack is done. We have to drop the tracker table as well
+                # to not leave any Psycopack relations behind.
                 self.command.drop_table_if_exists(table=self.tracker_table)
                 return
             case _:  # pragma: no cover
@@ -253,7 +253,7 @@ class Tracker:
         )
         # The unique index below will guarantee that there is ever only one row
         # in the table with finished_at NULL. This represents the logical
-        # constraint of not being possible to carry on two repacking stages at
+        # constraint of not being possible to carry on two Psycopack stages at
         # the same time.
         # Due to the limitations of having to support lower versions than
         # Postgres 15, we can't use NULLS NOT DISTINCT and need the workaround
@@ -421,7 +421,7 @@ class Tracker:
             current_stage = self.get_current_stage()
             if current_stage != Stage.CLEAN_UP:
                 raise CannotRevertSwap(
-                    "Can only revert if a swap was the last completed repacking stage."
+                    "Can only revert if a swap was the last completed Psycopack stage."
                 )
 
             self._delete_current_stage()


### PR DESCRIPTION
Prior to this change, this class was named Repack after the pg_repack Postgres extension, as it served as inspiration for this code.

However, in future the documentation will refer to this class as the entry point for the Python interface of the package.

Renaming the Repack class to Psycopack will help newbie users (or experienced users who don't know what "repack" means in the context of Postgres) to not have to load more context into their brain if all they want to do is process a schema change safely.