### PR TITLE
Better Ergonomics For Psycopg2

### DIFF
--- a/src/psycopack/__init__.py
+++ b/src/psycopack/__init__.py
@@ -3,6 +3,7 @@ A customizable way to repack a table using psycopg.
 """
 
 from ._conn import get_db_connection
+from ._cur import get_cursor
 from ._introspect import BackfillBatch
 from ._repack import (
     BasePsycopackError,
@@ -46,5 +47,6 @@ __all__ = (
     "TableHasTriggers",
     "TableIsEmpty",
     "UnsupportedPrimaryKey",
+    "get_cursor",
     "get_db_connection",
 )

--- a/src/psycopack/_repack.py
+++ b/src/psycopack/_repack.py
@@ -128,14 +128,14 @@ class Psycopack:
         table: str,
         batch_size: int,
         conn: psycopg.Connection,
-        cur: psycopg.Cursor,
+        cur: _cur.LoggedCursor,
         convert_pk_to_bigint: bool = False,
         post_backfill_batch_callback: PostBackfillBatchCallback | None = None,
         lock_timeout: datetime.timedelta = datetime.timedelta(seconds=10),
         schema: str = "public",
     ) -> None:
         self.conn = conn
-        self.cur = _cur.LoggedCursor(cur=cur)
+        self.cur = cur
         self.introspector = _introspect.Introspector(
             conn=self.conn,
             cur=self.cur,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from typing import Generator
 
 import pytest
 
-from psycopack import _conn
+from psycopack import _conn, _cur
 from psycopack import _psycopg as psycopg
 
 
@@ -16,20 +16,17 @@ DATABASE_NAME = os.getenv("DATABASE_NAME", "test_psycopack")
 @pytest.fixture
 def connection() -> Generator[psycopg.Connection, None, None]:
     with _conn.get_db_connection(DATABASE_URL) as conn:
-        cur = conn.cursor()
-        if not psycopg.PSYCOPG_3:  # pragma: no cover
-            # https://github.com/psycopg/psycopg2/issues/941#issuecomment-864025101
-            # https://github.com/psycopg/psycopg2/issues/1305#issuecomment-866712961
-            cur.execute("ABORT")
-        cur.execute(f'DROP DATABASE IF EXISTS "{DATABASE_NAME}" WITH (FORCE);')
-        cur.execute(f'CREATE DATABASE "{DATABASE_NAME}"')
+        with _cur.get_cursor(conn) as cur:
+            cur.execute(f'DROP DATABASE IF EXISTS "{DATABASE_NAME}" WITH (FORCE);')
+            cur.execute(f'CREATE DATABASE "{DATABASE_NAME}"')
 
         # Return (a new) connection. You can't directly change the db for an
         # existing connection. Once a connection is created for a db, it is
         # tied to that db.
         new_db_url = "/".join(DATABASE_URL.split("/")[:-1])
         new_db_url += f"/{DATABASE_NAME}"
-        with _conn.get_db_connection(new_db_url) as conn:
-            yield conn
+        with _conn.get_db_connection(new_db_url) as new_conn:
+            yield new_conn
 
-        cur.execute(f'DROP DATABASE IF EXISTS "{DATABASE_NAME}" WITH (FORCE)')
+        with _cur.get_cursor(conn) as cur:
+            cur.execute(f'DROP DATABASE IF EXISTS "{DATABASE_NAME}" WITH (FORCE)')

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,11 +1,11 @@
 from textwrap import dedent
 
-from psycopack import _psycopg
+from psycopack import _cur, _psycopg
 
 
 def create_table_for_repacking(
     connection: _psycopg.Connection,
-    cur: _psycopg.Cursor,
+    cur: _cur.LoggedCursor,
     table_name: str = "to_repack",
     rows: int = 100,
     referred_table_rows: int = 10,


### PR DESCRIPTION
Prior to this change, this package was relying on the default behaviour of Psycopg for cursor instantiation.

The problem is that there are differences between Psycopg 2 and Psycopg 3 that make this unfeasible for this library, which supports both versions.

For example, when a cursor is instantiated from the connection context manager, Psycopg 2 starts a transaction automatically [1][2], whereas Psycopg 3 doesn't.
```
  with connection.cursor() as cur:
      # There is already an implicit "BEGIN;" here on Psycopg 2.
      # But not on Psycopg 3
      ...
```
This problem came up when testing Psycopack locally using Psycopg 2.

The following ABORT call had to be added or else the procedure would fail when creating indexes CONCURRENTLY, as that can't happen inside a transaction.
```
  from psycopack import psycopack, get_db_connection

  with get_db_connection("postgresql://user:password@host:port/db") as conn:
      with conn.cursor() as cur:
          cur.execute("ABORT;")
          psycopack = Psycopack(
              batch_size=50_000,
              conn=conn,
              cur=cur,
              schema="public",
              table="to_psycopack",
              # Set this argument and Psycopack will do the conversion
              # automatically.
              convert_pk_to_bigint=True,
          )
          psycopack.sync_schemas()
```
In any case, Psycopack handles its own transactions and does not need to rely on arbitrary library designs.

- [1] https://github.com/psycopg/psycopg2/issues/941#issuecomment-864025101
- [2] https://github.com/psycopg/psycopg2/issues/1305#issuecomment-866712961