### PR TITLE
Allow empty table with `allow_empty` flag

### DIFF
--- a/src/psycopack/_introspect.py
+++ b/src/psycopack/_introspect.py
@@ -122,7 +122,9 @@ class Introspector:
         )
         return [r[0] for r in self.cur.fetchall()]
 
-    def get_min_and_max_pk(self, *, table: str, pk_column: str) -> tuple[int, int]:
+    def get_min_and_max_pk(
+        self, *, table: str, pk_column: str
+    ) -> tuple[int, int] | None:
         self.cur.execute(
             psycopg.sql.SQL(
                 dedent("""
@@ -141,6 +143,9 @@ class Introspector:
         )
         result = self.cur.fetchone()
         assert result is not None
+        if result == (None, None):
+            # table is empty
+            return None
         min_pk, max_pk = result
         assert isinstance(min_pk, int)
         assert isinstance(max_pk, int)

--- a/tests/test_repack.py
+++ b/tests/test_repack.py
@@ -267,6 +267,22 @@ def test_when_table_is_empty(connection: _psycopg.Connection) -> None:
             ).full()
 
 
+def test_when_table_is_empty_with_allow_empty(
+    connection: _psycopg.Connection,
+) -> None:
+    with _cur.get_cursor(connection) as cur:
+        cur.execute("CREATE TABLE empty_table (id SERIAL PRIMARY KEY);")
+
+        # doesn't raise TableIsEmpty
+        Psycopack(
+            table="empty_table",
+            batch_size=1,
+            conn=connection,
+            cur=cur,
+            allow_empty=True,
+        ).full()
+
+
 def test_repack_full_after_pre_validate_called(connection: _psycopg.Connection) -> None:
     """
     full() should be able to be called no matter where the repacking process


### PR DESCRIPTION
Prior to this change, running psycopack on an empty table would cause the `TableIsEmpty` exception to be raised.

This change adds an `allow_empty` option to allow empty tables to be handled without raising an exception. This enables psycopack to be used (e.g. for schema changes) irrespective of whether the table is empty or not.

This PR has been changed following discussions in [this thread](https://krakentech.slack.com/archives/C084W8MDFBQ/p1748998604226979); here's the previous description:

~~Prior to this change, running psycopack on an empty table would cause the `TableIsEmpty` exception to be raised.~~

~~This change adds a check for a schema change (initially just PK bigint conversion) before checking for an empty table. This enables psycopack to be used for schema changes irrespective of whether the table is empty or not.~~