### PR TITLE
Make `Stage` public

### DIFF
--- a/src/psycopack/__init__.py
+++ b/src/psycopack/__init__.py
@@ -24,7 +24,7 @@ from ._repack import (
     TableIsEmpty,
     UnsupportedPrimaryKey,
 )
-from ._tracker import FailureDueToLockTimeout
+from ._tracker import FailureDueToLockTimeout, Stage
 
 
 __all__ = (
@@ -43,6 +43,7 @@ __all__ = (
     "PrimaryKeyNotFound",
     "ReferringForeignKeyInDifferentSchema",
     "Psycopack",
+    "Stage",
     "TableDoesNotExist",
     "TableHasTriggers",
     "TableIsEmpty",


### PR DESCRIPTION
This change makes the `Stage` enum public so that applications can use it (along with the tracker method `get_current_stage`) to determine which stage the Psycopack process is up to.