### PR TITLE
Set up backfill log with separate positive and negative ranges

### DIFF
--- a/src/psycopack/_introspect.py
+++ b/src/psycopack/_introspect.py
@@ -123,16 +123,25 @@ class Introspector:
         return [r[0] for r in self.cur.fetchall()]
 
     def get_min_and_max_pk(
-        self, *, table: str, pk_column: str
+        self, *, table: str, pk_column: str, positive: bool
     ) -> tuple[int, int] | None:
+        if positive:
+            # positive range
+            where_sql = "WHERE {pk_column} >= 0;"
+        else:
+            # negative range
+            where_sql = "WHERE {pk_column} < 0;"
         self.cur.execute(
             psycopg.sql.SQL(
-                dedent("""
-                SELECT
-                  MIN({pk_column}) AS min_pk,
-                  MAX({pk_column}) AS max_pk
-                FROM {schema}.{table};
-                """)
+                dedent(
+                    """
+                    SELECT
+                      MIN({pk_column}) AS min_pk,
+                      MAX({pk_column}) AS max_pk
+                    FROM {schema}.{table}
+                    """
+                    + where_sql
+                )
             )
             .format(
                 table=psycopg.sql.Identifier(table),

--- a/src/psycopack/_repack.py
+++ b/src/psycopack/_repack.py
@@ -627,9 +627,26 @@ class Psycopack:
         self.command.create_backfill_log(table=self.backfill_log)
 
     def _populate_backfill_log(self) -> None:
+        # positive pk values
         min_and_max = self.introspector.get_min_and_max_pk(
             table=self.table,
             pk_column=self.pk_column,
+            positive=True,
+        )
+        if min_and_max is not None:
+            min_pk, max_pk = min_and_max
+            self.command.populate_backfill_log(
+                table=self.backfill_log,
+                batch_size=self.batch_size,
+                min_pk=min_pk,
+                max_pk=max_pk,
+            )
+
+        # negative pk values
+        min_and_max = self.introspector.get_min_and_max_pk(
+            table=self.table,
+            pk_column=self.pk_column,
+            positive=False,
         )
         if min_and_max is not None:
             min_pk, max_pk = min_and_max

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -216,3 +216,34 @@ def create_table_for_repacking(
         SELECT generate_series(1, {referring_table_rows});
     """)
     )
+
+
+def create_table_for_backfilling(
+    cur: _cur.Cursor,
+    table_name: str = "to_backfill",
+    positive_rows: int = 100,
+    negative_rows: int = 100,
+) -> None:
+    cur.execute(
+        dedent(f"""
+            CREATE TABLE {table_name} (
+                id SERIAL PRIMARY KEY
+            );
+        """)
+    )
+
+    if positive_rows > 0:
+        cur.execute(
+            dedent(f"""
+                INSERT INTO {table_name} (id) SELECT generate_series(1, {positive_rows});
+            """)
+        )
+
+    if negative_rows > 0:
+        negative_base = -1000  # arbitrary
+        cur.execute(
+            dedent(f"""
+                INSERT INTO {table_name} (id)
+                SELECT generate_series({negative_base}, {negative_base} + {negative_rows} - 1);
+            """)
+        )


### PR DESCRIPTION
Prior to this change, if the table being repacked used negative pk values, the backfill would cover the entire range from min(pk) to 0 (as well as the positive values). When negative pk values have been used after positive values are nearing exhaustion, it's likely that most of the negative range is empty and therefore does not need to be backfilled.

This change checks for min(pk) and max(pk) separately for positive values and negative values, to avoid backfilling empty negative ranges.