### PR TITLE
Add ANALYZE to the sync_schemas step

### DIFF
--- a/src/psycopack/_commands.py
+++ b/src/psycopack/_commands.py
@@ -542,6 +542,16 @@ class Command:
             .as_string(self.conn)
         )
 
+    def analyze(self, *, table: str) -> None:
+        self.cur.execute(
+            psycopg.sql.SQL("ANALYZE {schema}.{table};")
+            .format(
+                table=psycopg.sql.Identifier(table),
+                schema=psycopg.sql.Identifier(self.schema),
+            )
+            .as_string(self.conn)
+        )
+
     @contextmanager
     def db_transaction(self) -> Iterator[None]:
         self.cur.execute("BEGIN;")

--- a/src/psycopack/_repack.py
+++ b/src/psycopack/_repack.py
@@ -353,6 +353,7 @@ class Psycopack:
                 self._create_unique_constraints()
                 self._create_check_and_fk_constraints()
                 self._create_referring_fks()
+                self.command.analyze(table=self.table)
 
     def swap(self) -> None:
         """


### PR DESCRIPTION
Prior to this change, the repacked table might have no statistics, or out-of-date statistics (if autoanalyze had been triggered during backfilling).

This change adds an explicit ANALYZE command to the sync_schemas step to ensure that the table statistics are reasonably up to date.