### PR TITLE
Make "PostBackfillBatchCallback" public

### DIFF
--- a/src/psycopack/__init__.py
+++ b/src/psycopack/__init__.py
@@ -16,6 +16,7 @@ from ._repack import (
     NoReferencesPrivilege,
     NoReferringTableOwnership,
     NotTableOwner,
+    PostBackfillBatchCallback,
     PrimaryKeyNotFound,
     Psycopack,
     ReferringForeignKeyInDifferentSchema,


### PR DESCRIPTION
This change makes `PostBackfillBatchCallback` public, so that when `Psycopack` is instantiated with a `post_backfill_batch_callback` argument, type checking the argument is possible.