### PR TITLE
Add `skip_permissions_check` option to Psycopack

### DIFF
--- a/src/psycopack/_repack.py
+++ b/src/psycopack/_repack.py
@@ -134,6 +134,7 @@ class Psycopack:
         lock_timeout: datetime.timedelta = datetime.timedelta(seconds=10),
         schema: str = "public",
         allow_empty: bool = False,
+        skip_permissions_check: bool = False,
     ) -> None:
         self.conn = conn
         self.cur = cur
@@ -152,7 +153,8 @@ class Psycopack:
         self.table = table
         self.schema = schema
         self._check_table_exists()
-        self._check_user_permissions()
+        if not skip_permissions_check:
+            self._check_user_permissions()
 
         self.batch_size = batch_size
         self.post_backfill_batch_callback = post_backfill_batch_callback

--- a/tests/test_repack.py
+++ b/tests/test_repack.py
@@ -2026,3 +2026,27 @@ def test_populate_backfill_log(
         )
         result = cur.fetchall()
         assert result == expected_ranges
+
+
+def test_with_skip_permissions_check(
+    connection: _psycopg.Connection,
+) -> None:
+    with _cur.get_cursor(connection, logged=True) as cur:
+        factories.create_table_for_repacking(
+            connection=connection,
+            cur=cur,
+            table_name="to_repack",
+            rows=100,
+        )
+
+        with mock.patch.object(
+            Psycopack, "_check_user_permissions", autospec=True
+        ) as mocked:
+            Psycopack(
+                table="to_repack",
+                batch_size=1,
+                conn=connection,
+                cur=cur,
+                skip_permissions_check=True,
+            )
+            mocked.assert_not_called()


### PR DESCRIPTION
Previously, the permissions check was done each time a Psycopack object was instantiated. The check looks for the permissions needed for the complete operation, including all the individual steps. However, one step, `backfill()`, doesn't require the much higher elevated permissions that the other steps require. Following the principle of least privilege, it might be desirable to run the `backfill()` step using a Postgres user with lower privileges than the user used for the other steps.

This change adds a skip_permissions_check option to Psycopack which enables its use with a less-privileged Postgres user.