### PR TITLE
Fix queries to consider role membership as well as table ownership

### DIFF
--- a/src/psycopack/_introspect.py
+++ b/src/psycopack/_introspect.py
@@ -264,7 +264,14 @@ class Introspector:
                   pg_namespace.nspname AS schema,
                   (
                     SELECT
-                      tableowner = current_user
+                      tableowner = current_user OR tableowner IN (
+                        SELECT
+                          rolname
+                        FROM
+                          pg_roles
+                        WHERE
+                          pg_has_role(current_user, pg_roles.oid, 'MEMBER')
+                      )
                     FROM
                       pg_tables
                     WHERE
@@ -657,7 +664,14 @@ class Introspector:
             psycopg.sql.SQL(
                 dedent("""
                 SELECT
-                  tableowner = current_user
+                  tableowner = current_user OR tableowner IN (
+                    SELECT
+                      rolname
+                    FROM
+                      pg_roles
+                    WHERE
+                      pg_has_role(current_user, pg_roles.oid, 'MEMBER')
+                    )
                 FROM
                   pg_tables
                 WHERE


### PR DESCRIPTION
Prior to this change, the introspections that looked to see whether the current user owned a particular table only considered direct ownership. But in the case of a table owned by a role, any user that has that role also effectively owns the table, and has permission to operate on the table as if they were the direct owner.

This change updates the `get_referring_fks` and `is_table_owner` introspection functions to consider both direct ownership and also indirect ownership via role membership.