### PR TITLE
Fix pk sequence value update when negative pk values are in use

### DIFF
--- a/src/psycopack/_commands.py
+++ b/src/psycopack/_commands.py
@@ -74,17 +74,18 @@ class Command:
             .as_string(self.conn)
         )
 
-    def create_sequence(self, *, seq: str, bigint: bool) -> None:
+    def create_sequence(self, *, seq: str, bigint: bool, minvalue: int) -> None:
         if bigint:
-            sql = "CREATE SEQUENCE {schema}.{seq} AS BIGINT;"
+            sql = "CREATE SEQUENCE {schema}.{seq} AS BIGINT MINVALUE {minvalue};"
         else:
-            sql = "CREATE SEQUENCE {schema}.{seq};"
+            sql = "CREATE SEQUENCE {schema}.{seq} MINVALUE {minvalue};"
 
         self.cur.execute(
             psycopg.sql.SQL(sql)
             .format(
                 seq=psycopg.sql.Identifier(seq),
                 schema=psycopg.sql.Identifier(self.schema),
+                minvalue=psycopg.sql.Literal(minvalue),
             )
             .as_string(self.conn)
         )

--- a/src/psycopack/_introspect.py
+++ b/src/psycopack/_introspect.py
@@ -628,6 +628,26 @@ class Introspector:
         assert isinstance(value, int)
         return value
 
+    def get_pk_sequence_min_value(self, *, seq: str) -> int:
+        self.cur.execute(
+            psycopg.sql.SQL(
+                dedent("""
+                    SELECT min_value FROM pg_sequences
+                    WHERE schemaname = {schema} AND sequencename = {sequence};
+                """)
+            )
+            .format(
+                schema=psycopg.sql.Literal(self.schema),
+                sequence=psycopg.sql.Literal(seq),
+            )
+            .as_string(self.conn)
+        )
+        result = self.cur.fetchone()
+        assert result is not None
+        value = result[0]
+        assert isinstance(value, int)
+        return value
+
     def get_backfill_batch(self, *, table: str) -> BackfillBatch | None:
         self.cur.execute(
             psycopg.sql.SQL(

--- a/src/psycopack/_repack.py
+++ b/src/psycopack/_repack.py
@@ -599,7 +599,7 @@ class Psycopack:
                 always=(pk_info.identity_type == "a"),
                 pk_column=self.pk_column,
             )
-        elif self.introspector.get_pk_sequence_name(table=self.table):
+        elif seq := self.introspector.get_pk_sequence_name(table=self.table):
             # Create a new sequence for the copied table's id column so that it
             # does not depend on the original's one. Otherwise, we wouldn't be
             # able to delete the original table after the repack process is
@@ -608,6 +608,7 @@ class Psycopack:
             self.command.create_sequence(
                 seq=self.id_seq,
                 bigint=("big" in pk_info.data_types[0].lower()),
+                minvalue=self.introspector.get_pk_sequence_min_value(seq=seq),
             )
             self.command.set_table_id_seq(
                 table=self.copy_table,

--- a/src/psycopack/_repack.py
+++ b/src/psycopack/_repack.py
@@ -403,7 +403,6 @@ class Psycopack:
                     self.command.transfer_pk_sequence_value(
                         source_table=self.table,
                         dest_table=self.copy_table,
-                        convert_pk_to_bigint=self.convert_pk_to_bigint,
                     )
                 self.command.rename_table(
                     table_from=self.table, table_to=self.repacked_name
@@ -461,7 +460,6 @@ class Psycopack:
                 self.command.transfer_pk_sequence_value(
                     source_table=self.table,
                     dest_table=self.repacked_name,
-                    convert_pk_to_bigint=self.convert_pk_to_bigint,
                 )
 
             self.command.rename_table(table_from=self.table, table_to=self.copy_table)
@@ -506,6 +504,11 @@ class Psycopack:
                     table=self.table, trigger=self.repacked_trigger
                 )
                 self.command.drop_function_if_exists(function=self.repacked_function)
+
+                if self.convert_pk_to_bigint and self.introspector.get_pk_sequence_name(
+                    table=self.table
+                ):
+                    self.command.update_pk_sequence_value(table=self.table)
 
                 for idx_sql in indexes:
                     for index_data in indexes[idx_sql]:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -70,6 +70,12 @@ def create_table_for_repacking(
         );
     """)
     )
+    if "serial" in pk_type.lower():
+        seq = f"{table_name}_{pk_name}_seq"
+        cur.execute(
+            f"ALTER SEQUENCE {schema}.{seq} MINVALUE {pk_start} RESTART WITH {pk_start};"
+        )
+
     cur.execute(f"CREATE INDEX btree_idx ON {schema}.{table_name} (var_with_btree);")
     cur.execute(
         f"CREATE INDEX pattern_ops_idx ON {schema}.{table_name} (var_with_pattern_ops varchar_pattern_ops);"

--- a/tests/test_repack.py
+++ b/tests/test_repack.py
@@ -3,8 +3,6 @@ from textwrap import dedent
 from typing import Tuple, Union
 from unittest import mock
 
-from psycopg.errors import NumericValueOutOfRange
-
 import pytest
 
 from psycopack import (
@@ -1399,15 +1397,6 @@ def test_when_table_has_negative_pk_values(
         )
 
 
-@pytest.mark.xfail(
-    raises=NumericValueOutOfRange,
-    reason="""
-E           psycopg.errors.NumericValueOutOfRange: integer out of range
-E           CONTEXT:  SQL function "psycopack_repacked_6723301_fun" statement 1
-E           SQL statement "SELECT "public"."psycopack_repacked_6723301_fun"(NEW."id", NEW."id")"
-E           PL/pgSQL function psycopack_repacked_6723301_tgr() line 4 at PERFORM
-""",
-)
 def test_with_writes_when_table_has_negative_pk_values(
     connection: _psycopg.Connection,
 ) -> None:

--- a/tests/test_repack.py
+++ b/tests/test_repack.py
@@ -1397,8 +1397,17 @@ def test_when_table_has_negative_pk_values(
         )
 
 
+@pytest.mark.parametrize(
+    "initial_pk_type",
+    (
+        "integer",
+        "serial",
+        "smallint",
+        "smallserial",
+    ),
+)
 def test_with_writes_when_table_has_negative_pk_values(
-    connection: _psycopg.Connection,
+    connection: _psycopg.Connection, initial_pk_type: str
 ) -> None:
     with _cur.get_cursor(connection, logged=True) as cur:
         factories.create_table_for_repacking(
@@ -1406,7 +1415,7 @@ def test_with_writes_when_table_has_negative_pk_values(
             cur=cur,
             table_name="to_repack",
             rows=100,
-            pk_type="integer",
+            pk_type=initial_pk_type,
             pk_start=-200,
         )
         table_before = _collect_table_info(table="to_repack", connection=connection)


### PR DESCRIPTION
If the table is being converted to a bigint pk and the pk sequence has been set to negative, we want to reset the sequence value to 2**31 so that it can start using the new bigint range (and not run out of negative values when the sequence advances to 1).

Previously that reset was done in the `swap` stage. But that led to errors, since the old table was being updated by a trigger, and it only had an integer pk.

This change moves the sequence reset to the `clean_up` stage after the trigger has been dropped, which fixes the bug. The change also ensures that the sequence on the new table has the same min value as the old sequence (which could be negative).

Fixes #49